### PR TITLE
Measure performance stats via software

### DIFF
--- a/src/include/pka_cpu.h
+++ b/src/include/pka_cpu.h
@@ -46,7 +46,6 @@
 
 #include "pka_common.h"
 
-#define PKA_AARCH_64
 #define MAX_CPU_NUMBER 16      // BlueField specific
 
 #define MEGA 1000000


### PR DESCRIPTION
* With PKA_AARCH_64 defined, CPU cycles are read from system counters and
  then used to calculate the time elapsed. With PKA_AARCH_64 disabled,
  time elapsed/CPU cycles will be evaluated via software libraries.
  The performance measured matches to that measured with PMU counters enabled,
  which is deemed to be accurate.

* This eradicates the issue of inaccuracy in measurements introduced by using
  system counters and also removes the dependency on PMU driver required
  while measuring with PMU counters.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>