### PR TITLE
fix multithreading issue

### DIFF
--- a/src/tests/performance/pka_test_performance.c
+++ b/src/tests/performance/pka_test_performance.c
@@ -1529,7 +1529,7 @@ static void execute_tests_by_thread(uint32_t        thread_idx,
         //printf("[%d] total_cmds_done=%u - failure_cnt=%u\n",
         //      thread_idx, total_cmds_done, failure_cnt);
 
-        if (failure_cnt > 10)
+        else if (failure_cnt++ > 10)
             break;
 
         if ((cmds_left_to_submit == 0) && (num_cmds == total_cmds_done))


### PR DESCRIPTION
pka_get_result returns FAILURE when the result queue is empty,
threads should break out of the loop when the failure count exceeds
the limit else they can be stuck there forever.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>