### PR TITLE
Bug fixes

### DIFF
--- a/lib/pka_internal.h
+++ b/lib/pka_internal.h
@@ -136,8 +136,8 @@ typedef struct
 
 typedef struct
 {
-    pka_cmd_stats_t cmd_stats[256]; ///< stats entry
-    uint8_t         index;          ///< index in 0 .. 255.
+    pka_cmd_stats_t cmd_stats[4096]; ///< stats entry
+    uint16_t        index:12;        ///< index in 0 .. 4095, wrapping is permitted.
 } pka_cmd_stats_db_t;
 
 static pka_cmd_stats_db_t pka_cmd_stats_db[PKA_MAX_QUEUES_NUM];

--- a/lib/pka_ring.h
+++ b/lib/pka_ring.h
@@ -278,8 +278,8 @@ typedef struct
 // Note that a data base should be associated with a hardware ring.
 typedef struct
 {
-    pka_udata_info_t entries[32]; // user data information entries.
-    uint8_t          index   : 5; // entry index. Wrapping is permitted.
+    pka_udata_info_t entries[256]; // user data information entries.
+    uint8_t          index;        // entry index. Wrapping is permitted.
 } pka_udata_db_t;
 
 #ifndef __KERNEL__


### PR DESCRIPTION
* Fix issues in the queue and ring layer.
  Queue layer: Issues in the queue layer are mostly associated with
  incorrect wrapping around the queue boundary. Use a temp buffer to alleviate
  this problem.

  Ring layer: The command and user data stats database size needs to be
  increased in order to accomodate commands and associated stats.
  Command stats size(4096) is approximated based on the number of commands
  that can be enqueued to ring directly (32 rings * 16 cmd descriptors) +
  Number of commands that can be enqueued to the sw queue (~2000) of a thread.
  The above approximation is based on max queue memory and min size
  occupied by a command in the queue.

* Fix issues in the Multithreading test framework.
  The start and end barrier are placed incorrectly. The end barrier
  after 'pka_term_local()' causes the 'workers_cnt' to be decremented
  when there are other threads still processing. This causes some threads
  to be skipped while checking for waiting threads. This skip is caused
  as we check the 'workers_cnt' shared variable to determine the number of
  threads to be processed in a loop and undue decrement of this variable
  causes the skip.

* Fix the speed calculation(cmds/sec) by using the number of correct answers
  retrieved instead of total number of commands submitted.

* Use ticks read from register to approximate the time/cycles elapsed. This gives
  accurate approximation than the software method. Furthermore, this eradicates the
  need for additional kernel module to get the same accuracy.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>