### PR TITLE
Print debug for error:EPERM

### DIFF
--- a/include/pka_cpu.h
+++ b/include/pka_cpu.h
@@ -138,7 +138,7 @@ static void *pka_cpu_read_sysfs(size_t *file_len, const char *filename)
     fd = open(filename, O_RDONLY);
     if (fd == -EPERM)
     {
-        PKA_ERROR(PKA_CPU, "\nOpening file failed with error:%d.\n", errno);
+        PKA_DEBUG(PKA_USER, "\nOpening file failed with error:%d.\n", errno);
         return NULL;
     }
 


### PR DESCRIPTION
* SMBIOS sysfs entry has permissions only for root user.
  hence trying to read this file fails with -EPERM error for non-root user.
  This can be alarming for QA/users when they use PKA as a non-root user.
  Hence print this error message only when debugging is enabled.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>