### PR TITLE
Create missing engine symlink in CentOS

### DIFF
--- a/libpka.spec
+++ b/libpka.spec
@@ -31,6 +31,31 @@ PKA hardware.
 
 %install
 %make_install
+%if 0%{?rhel} == 7
+    mkdir -p $RPM_BUILD_ROOT%{_libdir}/openssl/engines
+    cp $RPM_BUILD_ROOT%{_libdir}/libbfengine.so.*.*.* $RPM_BUILD_ROOT%{_libdir}/openssl/engines/
+%endif
+%if 0%{?rhel} == 8
+    mkdir -p $RPM_BUILD_ROOT%{_libdir}/engines-1.1
+    cp $RPM_BUILD_ROOT%{_libdir}/libbfengine.so.*.*.* $RPM_BUILD_ROOT%{_libdir}/engines-1.1/
+%endif
+
+%preun
+%if 0%{?rhel} == 7
+    rm -f %{_libdir}/openssl/engines/libpka.so
+%endif
+%if 0%{?rhel} == 8
+    rm -f %{_libdir}/engines-1.1/pka.so
+%endif
+
+%post
+%if 0%{?rhel} == 7
+    ln -s %{_libdir}/openssl/engines/libbfengine.so.*.*.* %{_libdir}/openssl/engines/libpka.so
+%endif
+%if 0%{?rhel} == 8
+    ln -s %{_libdir}/engines-1.1/libbfengine.so.*.*.* %{_libdir}/engines-1.1/pka.so
+%endif
+
 
 %files
 %defattr(-, root, root)
@@ -38,5 +63,11 @@ PKA hardware.
 %{_libdir}/libPKA*
 %{_libdir}/libbfengine*
 %{_bindir}/*
+%if 0%{?rhel} == 7
+    %{_libdir}/openssl/engines/libbfengine*
+%endif
+%if 0%{?rhel} == 8
+    %{_libdir}/engines-1.1/libbfengine*
+%endif
 
 %doc COPYING


### PR DESCRIPTION
* Update the rpm spec file to install pka engine
  in the openssl engine directory and create a symlink
  which will be used when loading pka engine into openssl dynamically.

* The openssl engine directory if different between openssl versions
  in CentOS 7 and 8. Also, the name of the symlink differs based on
  the openssl version installed.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>