### PR TITLE
Fix ring open when rings are busy

### DIFF
--- a/lib/pka_dev.h
+++ b/lib/pka_dev.h
@@ -131,6 +131,10 @@ typedef struct
     uint32_t                num_cmd_desc;   ///< number of command descriptors.
 
     int8_t                  status;         ///< status of the ring.
+
+#ifdef __KERNEL__
+    struct mutex            mutex;          ///< mutex lock for sharing ring device
+#endif
 } pka_dev_ring_t;
 
 /// defines for pka_dev_ring->status


### PR DESCRIPTION
* kernel: Introduce mutex lock/unlock when updating
          ring status while open/close ring device. If ring status
          is busy while open operation then return -EBUSY error.

* userspace: If -EBUSY error is received while trying to open ring,
             this means the ring is being used by another application.
             Hence, continue to look for other rings that might be available.
             If ring open fails then no need to close the ring as this might affect
             other pka instances using that ring.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>