### PR TITLE
Use memory addresses defined in ACPI table

### DIFF
--- a/include/pka_addrs.h
+++ b/include/pka_addrs.h
@@ -66,75 +66,74 @@
 
 // EIP154 CSRS:
 
-#define PKA_EIP154_ADDR         0x400000
 // Global Control Space CSR addresses/offsets. These are accessed from the
 // ARM as 8 byte reads/writes however only the bottom 32 bits are implemented.
-#define PKA_CLOCK_SWITCH_ADDR   (0x11C68 | PKA_EIP154_ADDR)
-#define PKA_CLK_FORCE_ADDR      (0x11C80 | PKA_EIP154_ADDR)
-#define MODE_SELECTION_ADDR     (0x11C88 | PKA_EIP154_ADDR)
-#define PKA_PROT_STATUS_ADDR    (0x11C90 | PKA_EIP154_ADDR)
-#define PKA_OPTIONS_ADDR        (0x11DF0 | PKA_EIP154_ADDR)
-#define PKA_VERSION_ADDR        (0x11DF8 | PKA_EIP154_ADDR)
+#define PKA_CLOCK_SWITCH_ADDR   0x11C68
+#define PKA_CLK_FORCE_ADDR      0x11C80
+#define MODE_SELECTION_ADDR     0x11C88
+#define PKA_PROT_STATUS_ADDR    0x11C90
+#define PKA_OPTIONS_ADDR        0x11DF0
+#define PKA_VERSION_ADDR        0x11DF8
 
 // Advanced Interrupt Controller CSR addresses/offsets. These are accessed
 // from the ARM as 8 byte reads/writes however only the bottom 32 bits are
 // implemented.
-#define AIC_POL_CTRL_ADDR       (0x11E00 | PKA_EIP154_ADDR)
-#define AIC_TYPE_CTRL_ADDR      (0x11E08 | PKA_EIP154_ADDR)
-#define AIC_ENABLE_CTRL_ADDR    (0x11E10 | PKA_EIP154_ADDR)
-#define AIC_RAW_STAT_ADDR       (0x11E18 | PKA_EIP154_ADDR)
-#define AIC_ENABLE_SET_ADDR     (0x11E18 | PKA_EIP154_ADDR)
-#define AIC_ENABLED_STAT_ADDR   (0x11E20 | PKA_EIP154_ADDR)
-#define AIC_ACK_ADDR            (0x11E20 | PKA_EIP154_ADDR)
-#define AIC_ENABLE_CLR_ADDR     (0x11E28 | PKA_EIP154_ADDR)
-#define AIC_OPTIONS_ADDR        (0x11E30 | PKA_EIP154_ADDR)
-#define AIC_VERSION_ADDR        (0x11E38 | PKA_EIP154_ADDR)
+#define AIC_POL_CTRL_ADDR       0x11E00
+#define AIC_TYPE_CTRL_ADDR      0x11E08
+#define AIC_ENABLE_CTRL_ADDR    0x11E10
+#define AIC_RAW_STAT_ADDR       0x11E18
+#define AIC_ENABLE_SET_ADDR     0x11E18
+#define AIC_ENABLED_STAT_ADDR   0x11E20
+#define AIC_ACK_ADDR            0x11E20
+#define AIC_ENABLE_CLR_ADDR     0x11E28
+#define AIC_OPTIONS_ADDR        0x11E30
+#define AIC_VERSION_ADDR        0x11E38
 
 // The True Random Number Generator CSR addresses/offsets. These are accessed
 // from the ARM as 8 byte reads/writes however only the bottom 32 bits are
 // implemented.
-#define TRNG_OUTPUT_0_ADDR      (0x12000 | PKA_EIP154_ADDR)
-#define TRNG_OUTPUT_1_ADDR      (0x12008 | PKA_EIP154_ADDR)
-#define TRNG_OUTPUT_2_ADDR      (0x12010 | PKA_EIP154_ADDR)
-#define TRNG_OUTPUT_3_ADDR      (0x12018 | PKA_EIP154_ADDR)
-#define TRNG_STATUS_ADDR        (0x12020 | PKA_EIP154_ADDR)
-#define TRNG_INTACK_ADDR        (0x12020 | PKA_EIP154_ADDR)
-#define TRNG_CONTROL_ADDR       (0x12028 | PKA_EIP154_ADDR)
-#define TRNG_CONFIG_ADDR        (0x12030 | PKA_EIP154_ADDR)
-#define TRNG_ALARMCNT_ADDR      (0x12038 | PKA_EIP154_ADDR)
-#define TRNG_FROENABLE_ADDR     (0x12040 | PKA_EIP154_ADDR)
-#define TRNG_FRODETUNE_ADDR     (0x12048 | PKA_EIP154_ADDR)
-#define TRNG_ALARMMASK_ADDR     (0x12050 | PKA_EIP154_ADDR)
-#define TRNG_ALARMSTOP_ADDR     (0x12058 | PKA_EIP154_ADDR)
-#define TRNG_BLOCKCNT_ADDR      (0x120E8 | PKA_EIP154_ADDR)
-#define TRNG_OPTIONS_ADDR       (0x120F0 | PKA_EIP154_ADDR)
+#define TRNG_OUTPUT_0_ADDR      0x12000
+#define TRNG_OUTPUT_1_ADDR      0x12008
+#define TRNG_OUTPUT_2_ADDR      0x12010
+#define TRNG_OUTPUT_3_ADDR      0x12018
+#define TRNG_STATUS_ADDR        0x12020
+#define TRNG_INTACK_ADDR        0x12020
+#define TRNG_CONTROL_ADDR       0x12028
+#define TRNG_CONFIG_ADDR        0x12030
+#define TRNG_ALARMCNT_ADDR      0x12038
+#define TRNG_FROENABLE_ADDR     0x12040
+#define TRNG_FRODETUNE_ADDR     0x12048
+#define TRNG_ALARMMASK_ADDR     0x12050
+#define TRNG_ALARMSTOP_ADDR     0x12058
+#define TRNG_BLOCKCNT_ADDR      0x120E8
+#define TRNG_OPTIONS_ADDR       0x120F0
 
 // Control register address/offset. This is accessed from the ARM using 8
 // byte reads/writes however only the bottom 32 bits are implemented.
-#define PKA_MASTER_SEQ_CTRL_ADDR    (0x27F90 | PKA_EIP154_ADDR)
+#define PKA_MASTER_SEQ_CTRL_ADDR    0x27F90
 
 // Ring CSRs:  These are all accessed from the ARM using 8 byte reads/writes
 // however only the bottom 32 bits are implemented.
 
 // Ring 0 CSRS
-#define COMMAND_COUNT_0_ADDR    (0x80080 | PKA_EIP154_ADDR)
-#define RESULT_COUNT_0_ADDR     (0x80088 | PKA_EIP154_ADDR)
-#define IRQ_THRESH_0_ADDR       (0x80090 | PKA_EIP154_ADDR)
+#define COMMAND_COUNT_0_ADDR    0x80080
+#define RESULT_COUNT_0_ADDR     0x80088
+#define IRQ_THRESH_0_ADDR       0x80090
 
 // Ring 1 CSRS:
-#define COMMAND_COUNT_1_ADDR    (0x90080 | PKA_EIP154_ADDR)
-#define RESULT_COUNT_1_ADDR     (0x90088 | PKA_EIP154_ADDR)
-#define IRQ_THRESH_1_ADDR       (0x90090 | PKA_EIP154_ADDR)
+#define COMMAND_COUNT_1_ADDR    0x90080
+#define RESULT_COUNT_1_ADDR     0x90088
+#define IRQ_THRESH_1_ADDR       0x90090
 
 // Ring 2 CSRS:
-#define COMMAND_COUNT_2_ADDR    (0xA0080 | PKA_EIP154_ADDR)
-#define RESULT_COUNT_2_ADDR     (0xA0088 | PKA_EIP154_ADDR)
-#define IRQ_THRESH_2_ADDR       (0xA0090 | PKA_EIP154_ADDR)
+#define COMMAND_COUNT_2_ADDR    0xA0080
+#define RESULT_COUNT_2_ADDR     0xA0088
+#define IRQ_THRESH_2_ADDR       0xA0090
 
 // Ring 3 CSRS:
-#define COMMAND_COUNT_3_ADDR    (0xB0080 | PKA_EIP154_ADDR)
-#define RESULT_COUNT_3_ADDR     (0xB0088 | PKA_EIP154_ADDR)
-#define IRQ_THRESH_3_ADDR       (0xB0090 | PKA_EIP154_ADDR)
+#define COMMAND_COUNT_3_ADDR    0xB0080
+#define RESULT_COUNT_3_ADDR     0xB0088
+#define IRQ_THRESH_3_ADDR       0xB0090
 
 // EIP154 RAM regions: Note that the FARM_PROG_RAM_X address range overlaps
 // with the FARM_DATA_RAM_X and FARM_DATA_RAM_X_EXT address ranges.  This
@@ -164,115 +163,99 @@
 //          PKA Farm Data RAM extension size :   4KB  -->  8KB
 //          PKA Farm Program RAM size :          8KB  --> 16KB
 //
-#define PKA_BUFFER_RAM_BASE         (0x00000 | PKA_EIP154_ADDR)
+#define PKA_BUFFER_RAM_BASE         0x00000
 #define PKA_BUFFER_RAM_SIZE         MEM_SIZE_16KB   // 0x00000...0x03FFF
 
-#define PKA_SECURE_RAM_BASE         (0x20000 | PKA_EIP154_ADDR)
+#define PKA_SECURE_RAM_BASE         0x20000
 #define PKA_SECURE_RAM_SIZE         MEM_SIZE_16KB   // 0x20000...0x23FFF
 
-#define PKA_MASTER_PROG_RAM_BASE    (0x30000 | PKA_EIP154_ADDR)
+#define PKA_MASTER_PROG_RAM_BASE    0x30000
 #define PKA_MASTER_PROG_RAM_SIZE    MEM_SIZE_64KB   // 0x30000...0x3FFFF
 
-#define FARM_DATA_RAM_0_BASE        (0x40000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_0_BASE        0x40000
 #define FARM_DATA_RAM_0_SIZE        MEM_SIZE_8KB    // 0x40000...0x41FFF
-#define FARM_DATA_RAM_0_EXT_BASE    (0x42000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_0_EXT_BASE    0x42000
 #define FARM_DATA_RAM_0_EXT_SIZE    MEM_SIZE_8KB    // 0x42000...0x43FFF
-#define FARM_PROG_RAM_0_BASE        (0x40000 | PKA_EIP154_ADDR)
+#define FARM_PROG_RAM_0_BASE        0x40000
 #define FARM_PROG_RAM_0_SIZE        MEM_SIZE_16KB   // 0x40000...0x43FFF
-#define FARM_DATA_RAM_1_BASE        (0x44000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_1_BASE        0x44000
 #define FARM_DATA_RAM_1_SIZE        MEM_SIZE_8KB    // 0x44000...0x45FFF
-#define FARM_DATA_RAM_1_EXT_BASE    (0x46000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_1_EXT_BASE    0x46000
 #define FARM_DATA_RAM_1_EXT_SIZE    MEM_SIZE_8KB    // 0x46000...0x47FFF
-#define FARM_PROG_RAM_1_BASE        (0x44000 | PKA_EIP154_ADDR)
+#define FARM_PROG_RAM_1_BASE        0x44000
 #define FARM_PROG_RAM_1_SIZE        MEM_SIZE_16KB   // 0x44000...0x47FFF
-#define FARM_DATA_RAM_2_BASE        (0x48000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_2_BASE        0x48000
 #define FARM_DATA_RAM_2_SIZE        MEM_SIZE_8KB    // 0x48000...0x49FFF
-#define FARM_DATA_RAM_2_EXT_BASE    (0x4A000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_2_EXT_BASE    0x4A000
 #define FARM_DATA_RAM_2_EXT_SIZE    MEM_SIZE_8KB    // 0x4A000...0x4BFFF
-#define FARM_PROG_RAM_2_BASE        (0x48000 | PKA_EIP154_ADDR)
+#define FARM_PROG_RAM_2_BASE        0x48000
 #define FARM_PROG_RAM_2_SIZE        MEM_SIZE_16KB   // 0x48000...0x4BFFF
-#define FARM_DATA_RAM_3_BASE        (0x4C000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_3_BASE        0x4C000
 #define FARM_DATA_RAM_3_SIZE        MEM_SIZE_8KB    // 0x4C000...0x4DFFF
-#define FARM_DATA_RAM_3_EXT_BASE    (0x4E000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_3_EXT_BASE    0x4E000
 #define FARM_DATA_RAM_3_EXT_SIZE    MEM_SIZE_8KB    // 0x4E000...0x4FFFF
-#define FARM_PROG_RAM_3_BASE        (0x4C000 | PKA_EIP154_ADDR)
+#define FARM_PROG_RAM_3_BASE        0x4C000
 #define FARM_PROG_RAM_3_SIZE        MEM_SIZE_16KB   // 0x4C000...0x4FFFF
-#define FARM_DATA_RAM_4_BASE        (0x50000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_4_BASE        0x50000
 #define FARM_DATA_RAM_4_SIZE        MEM_SIZE_8KB    // 0x50000...0x51FFF
-#define FARM_DATA_RAM_4_EXT_BASE    (0x52000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_4_EXT_BASE    0x52000
 #define FARM_DATA_RAM_4_EXT_SIZE    MEM_SIZE_8KB    // 0x52000...0x53FFF
-#define FARM_PROG_RAM_4_BASE        (0x50000 | PKA_EIP154_ADDR)
+#define FARM_PROG_RAM_4_BASE        0x50000
 #define FARM_PROG_RAM_4_SIZE        MEM_SIZE_16KB   // 0x50000...0x53FFF
-#define FARM_DATA_RAM_5_BASE        (0x54000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_5_BASE        0x54000
 #define FARM_DATA_RAM_5_SIZE        MEM_SIZE_8KB    // 0x54000...0x55FFF
-#define FARM_DATA_RAM_5_EXT_BASE    (0x56000 | PKA_EIP154_ADDR)
+#define FARM_DATA_RAM_5_EXT_BASE    0x56000
 #define FARM_DATA_RAM_5_EXT_SIZE    MEM_SIZE_8KB    // 0x56000...0x57FFF
-#define FARM_PROG_RAM_5_BASE        (0x54000 | PKA_EIP154_ADDR)
+#define FARM_PROG_RAM_5_BASE        0x54000
 #define FARM_PROG_RAM_5_SIZE        MEM_SIZE_16KB   // 0x54000...0x57FFF
 
 // PKA Buffer RAM offsets. These are NOT real CSR's but instead are
 // specific offset/addresses within the EIP154 PKA_BUFFER_RAM.
 
 // Ring 0:
-#define RING_CMMD_BASE_0_ADDR   (0x00000 | PKA_EIP154_ADDR)
-#define RING_RSLT_BASE_0_ADDR   (0x00010 | PKA_EIP154_ADDR)
-#define RING_SIZE_TYPE_0_ADDR   (0x00020 | PKA_EIP154_ADDR)
-#define RING_RW_PTRS_0_ADDR     (0x00028 | PKA_EIP154_ADDR)
-#define RING_RW_STAT_0_ADDR     (0x00030 | PKA_EIP154_ADDR)
+#define RING_CMMD_BASE_0_ADDR   0x00000
+#define RING_RSLT_BASE_0_ADDR   0x00010
+#define RING_SIZE_TYPE_0_ADDR   0x00020
+#define RING_RW_PTRS_0_ADDR     0x00028
+#define RING_RW_STAT_0_ADDR     0x00030
 
 // Ring 1
-#define RING_CMMD_BASE_1_ADDR   (0x00040 | PKA_EIP154_ADDR)
-#define RING_RSLT_BASE_1_ADDR   (0x00050 | PKA_EIP154_ADDR)
-#define RING_SIZE_TYPE_1_ADDR   (0x00060 | PKA_EIP154_ADDR)
-#define RING_RW_PTRS_1_ADDR     (0x00068 | PKA_EIP154_ADDR)
-#define RING_RW_STAT_1_ADDR     (0x00070 | PKA_EIP154_ADDR)
+#define RING_CMMD_BASE_1_ADDR   0x00040
+#define RING_RSLT_BASE_1_ADDR   0x00050
+#define RING_SIZE_TYPE_1_ADDR   0x00060
+#define RING_RW_PTRS_1_ADDR     0x00068
+#define RING_RW_STAT_1_ADDR     0x00070
 
 // Ring 2
-#define RING_CMMD_BASE_2_ADDR   (0x00080 | PKA_EIP154_ADDR)
-#define RING_RSLT_BASE_2_ADDR   (0x00090 | PKA_EIP154_ADDR)
-#define RING_SIZE_TYPE_2_ADDR   (0x000A0 | PKA_EIP154_ADDR)
-#define RING_RW_PTRS_2_ADDR     (0x000A8 | PKA_EIP154_ADDR)
-#define RING_RW_STAT_2_ADDR     (0x000B0 | PKA_EIP154_ADDR)
+#define RING_CMMD_BASE_2_ADDR   0x00080
+#define RING_RSLT_BASE_2_ADDR   0x00090
+#define RING_SIZE_TYPE_2_ADDR   0x000A0
+#define RING_RW_PTRS_2_ADDR     0x000A8
+#define RING_RW_STAT_2_ADDR     0x000B0
 
 // Ring 3
-#define RING_CMMD_BASE_3_ADDR   (0x000C0 | PKA_EIP154_ADDR)
-#define RING_RSLT_BASE_3_ADDR   (0x000D0 | PKA_EIP154_ADDR)
-#define RING_SIZE_TYPE_3_ADDR   (0x000E0 | PKA_EIP154_ADDR)
-#define RING_RW_PTRS_3_ADDR     (0x000E8 | PKA_EIP154_ADDR)
-#define RING_RW_STAT_3_ADDR     (0x000F0 | PKA_EIP154_ADDR)
+#define RING_CMMD_BASE_3_ADDR   0x000C0
+#define RING_RSLT_BASE_3_ADDR   0x000D0
+#define RING_SIZE_TYPE_3_ADDR   0x000E0
+#define RING_RW_PTRS_3_ADDR     0x000E8
+#define RING_RW_STAT_3_ADDR     0x000F0
 
 // Ring Options
-#define PKA_RING_OPTIONS_ADDR   (0x07FF8 | PKA_EIP154_ADDR)
+#define PKA_RING_OPTIONS_ADDR   0x07FF8
 
-// Note the registers/memory below include MiCA specific PKA Control/Status
-// registers and the 64K RAM's that the EIP-154 calls Host Memory.
-
-// Note that Window RAM size is 64K however only the low 16K can be accessed.
-#define PKA_WINDOW_RAM_BASE             0x500000
-#define PKA_WINDOW_RAM_SIZE             MEM_SIZE_64KB
-#define PKA_WINDOW_RAM_REGION_SIZE      MEM_SIZE_16KB
-
-#define PKA_WINDOW_RAM_REGION_0_BASE    0x600000
-#define PKA_WINDOW_RAM_REGION_0_SIZE    PKA_WINDOW_RAM_REGION_SIZE
-#define PKA_WINDOW_RAM_REGION_1_BASE    0x610000
-#define PKA_WINDOW_RAM_REGION_1_SIZE    PKA_WINDOW_RAM_REGION_SIZE
-#define PKA_WINDOW_RAM_REGION_2_BASE    0x620000
-#define PKA_WINDOW_RAM_REGION_2_SIZE    PKA_WINDOW_RAM_REGION_SIZE
-#define PKA_WINDOW_RAM_REGION_3_BASE    0x630000
-#define PKA_WINDOW_RAM_REGION_3_SIZE    PKA_WINDOW_RAM_REGION_SIZE
+// Alternate Window RAM size
+#define PKA_WINDOW_RAM_REGION_SIZE  MEM_SIZE_16KB
 
 // Currently, we do not use these MiCA specific CSRs.
-#define PKI_EXT_CSR_START_ADDR          0x510000
-
 // The PKI (not EIP154) CSR address/offsets: These are all addressed as
 // 8-byte registers.
-#define PKA_INT_MASK_ADDR           (0x00 | PKI_EXT_CSR_START_ADDR)
-#define PKA_INT_MASK_SET_ADDR       (0x08 | PKI_EXT_CSR_START_ADDR)
-#define PKA_INT_MASK_RESET_ADDR     (0x10 | PKI_EXT_CSR_START_ADDR)
-#define PKA_ZEROIZE_ADDR            (0x40 | PKI_EXT_CSR_START_ADDR)
-#define TST_FRO_ADDR                (0x50 | PKI_EXT_CSR_START_ADDR)
-#define FRO_COUNT_ADDR              (0x58 | PKI_EXT_CSR_START_ADDR)
-#define PKA_PARITY_CTL_ADDR         (0x60 | PKI_EXT_CSR_START_ADDR)
-#define PKA_PARITY_STAT_ADDR        (0x68 | PKI_EXT_CSR_START_ADDR)
+#define PKA_INT_MASK_ADDR           0x00
+#define PKA_INT_MASK_SET_ADDR       0x08
+#define PKA_INT_MASK_RESET_ADDR     0x10
+#define PKA_ZEROIZE_ADDR            0x40
+#define TST_FRO_ADDR                0x50
+#define FRO_COUNT_ADDR              0x58
+#define PKA_PARITY_CTL_ADDR         0x60
+#define PKA_PARITY_STAT_ADDR        0x68
 
 #endif // __PKA_ADDRS_H__

--- a/include/pka_config.h
+++ b/include/pka_config.h
@@ -53,13 +53,10 @@
 // and ring spacing.
 #define PKA_RING_WORDS_ADDR         PKA_BUFFER_RAM_BASE
 #define PKA_RING_CNTRS_ADDR         COMMAND_COUNT_0_ADDR
-#define PKA_RING_MEM_0_BASE         PKA_WINDOW_RAM_BASE
-#define PKA_RING_MEM_1_BASE         PKA_WINDOW_RAM_REGION_0_BASE
 
 #define PKA_RING_WORDS_SIZE         0x40        // 64 bytes
 #define PKA_RING_CNTRS_SIZE         0x20        // 32 bytes (3 count registers)
-#define PKA_RING_MEM_0_SIZE         PKA_WINDOW_RAM_REGION_SIZE
-#define PKA_RING_MEM_1_SIZE         PKA_WINDOW_RAM_REGION_SIZE
+#define PKA_RING_MEM_SIZE           0x4000      // 16K bytes
 
 #define PKA_RING_WORDS_SPACING      0x40        // 64  bytes
 #define PKA_RING_CNTRS_SPACING      0x10000     // 64K bytes
@@ -75,11 +72,17 @@
 #define PKA_WINDOW_RAM_RING_MEM_SIZE         0x0800 //  2KB
 #define PKA_WINDOW_RAM_DATA_MEM_SIZE         0x3800 // 14KB
 
+#define PKA_WINDOW_RAM_OFFSET_MASK1       0x730000
+
 // Macro for mapping PKA Ring address into Window RAM address. It converts the
 // ring address, either physical address or virtual address, to valid address
-// into the Window RAM. This is done assuming the Window RAM base and size.
-#define PKA_RING_MEM_ADDR(addr, size) \
-    (PKA_WINDOW_RAM_BASE | (((addr) & 0xffff) | \
+// into the Window RAM. This is done assuming the Window RAM base, size and
+// mask. Here, base is the actual physical address of the Window RAM, with the
+// help of mask it is reduced to Window RAM offset within that PKA block.
+// Further, with the help of addr and size, we arrive at the Window RAM
+// offset address for a PKA Ring within the given Window RAM.
+#define PKA_RING_MEM_ADDR(base, mask, addr, size) \
+    ((base & mask) | (((addr) & 0xffff) | \
         ((((addr) & ~((size) - 1)) & 0xf0000) >> 2)))
 
 // PKA Master Sequencer Control/Status Register

--- a/lib/pka_dev.h
+++ b/lib/pka_dev.h
@@ -164,45 +164,63 @@ typedef struct
     uint8_t        res_cnt;
 } pka_dev_gbl_shim_res_info_t;
 
+struct pka_dev_mem_res
+{
+    uint64_t eip154_base;         ///< base address for eip154 mmio registers
+    uint64_t eip154_size;         ///< eip154 mmio register region size
+
+    uint64_t wndw_ram_off_mask;   ///< common offset mask for alt window ram and window ram
+    uint64_t wndw_ram_base;       ///< base address for window ram
+    uint64_t wndw_ram_size;       ///< window ram region size
+
+    uint64_t alt_wndw_ram_0_base; ///< base address for alternate window ram 0
+    uint64_t alt_wndw_ram_1_base; ///< base address for alternate window ram 1
+    uint64_t alt_wndw_ram_2_base; ///< base address for alternate window ram 2
+    uint64_t alt_wndw_ram_3_base; ///< base address for alternate window ram 3
+    uint64_t alt_wndw_ram_size;   ///< alternate window ram regions size
+
+    uint64_t csr_base;            ///< base address for csr registers
+    uint64_t csr_size;            ///< csr area size
+};
+
 /// PKA Shim structure
 struct pka_dev_shim_s
 {
-    uint64_t            base;             ///< shim base address
-    uint64_t            size;             ///< shim io memory size
+    struct pka_dev_mem_res mem_res;
 
-    uint64_t            trng_err_cycle;   ///< TRNG error cycle
+    uint64_t               trng_err_cycle;    ///< TRNG error cycle
 
-    uint32_t            shim_id;          ///< shim identifier
+    uint32_t               shim_id;           ///< shim identifier
 
-    uint32_t            rings_num;        ///< Number of supported rings (hw
-                                          ///  specific)
+    uint32_t               rings_num;         ///< Number of supported rings (hw
+                                              ///  specific)
 
-    pka_dev_ring_t    **rings;            ///< pointer to rings which belong to
-                                          ///  the shim.
+    pka_dev_ring_t       **rings;             ///< pointer to rings which belong to
+                                              ///  the shim.
 
-    uint8_t             ring_priority;    ///< specify the priority in which
-                                          ///  rings are handled.
+    uint8_t                ring_priority;     ///< specify the priority in which
+                                              ///  rings are handled.
 
-    uint8_t             ring_type;        ///< indicates whether the result
-                                          ///  ring delivers results strictly
-                                          ///  in-order.
+    uint8_t                ring_type;         ///< indicates whether the result
+                                              ///  ring delivers results strictly
+                                              ///  in-order.
 
-    pka_dev_shim_res_t  resources;        ///< shim resources
+    pka_dev_shim_res_t     resources;         ///< shim resources
 
-    uint8_t             window_ram_split; ///< Window RAM mode. if non-zero,
-                                          ///  the splitted window RAM scheme
-                                          ///  is used.
+    uint8_t                window_ram_split;  ///< Window RAM mode. if non-zero,
+                                              ///  the splitted window RAM scheme
+                                              ///  is used.
 
-    uint32_t            busy_ring_num;    ///< Number of active rings (rings in
-                                          ///  busy state)
+    uint32_t               busy_ring_num;     ///< Number of active rings (rings in
+                                              ///  busy state)
 
-    uint8_t             trng_enabled;     ///< Whether the TRNG engine is
-                                          ///  enabled.
+    uint8_t                trng_enabled;      ///< Whether the TRNG engine is
+                                              ///  enabled.
 
-    int8_t              status;           ///< status of the shim
+    int8_t                 status;            ///< status of the shim
 
 #ifdef __KERNEL__
-    struct mutex        mutex;            ///< mutex lock for sharing shim
+    struct mutex           mutex;             ///< mutex lock for sharing shim
 #endif
 };
 
@@ -273,8 +291,8 @@ int pka_dev_unregister_ring(pka_dev_ring_t *ring);
 
 /// Register PKA IO block. This function initializes a shim and configures its
 /// related resources, and returns a pointer to that ring.
-pka_dev_shim_t *pka_dev_register_shim(uint32_t shim_id, uint64_t shim_base,
-                           uint64_t shim_size, uint8_t shim_fw_id);
+pka_dev_shim_t *pka_dev_register_shim(uint32_t shim_id, uint8_t shim_fw_id,
+                                      struct pka_dev_mem_res *mem_res);
 
 /// Unregister PKA IO block
 int pka_dev_unregister_shim(pka_dev_shim_t *shim);


### PR DESCRIPTION
Instead of using #defines for memory addresses of different regions,
define these addresses as fixed memory addresses in ACPI table and
fetch them in driver. This way platform dependant memory addresses will
be isolated from the driver. This is particularly helpful for BF3 platform
update.

The memory regions being:
*EIP154 MMIO
*WINDOW RAM
*ALTERNATE WINDOW RAM
*CSR AREA

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>