### PR TITLE
Remove shared memory usage

### DIFF
--- a/lib/pka_internal.h
+++ b/lib/pka_internal.h
@@ -52,19 +52,6 @@
 #define PKA_DEFAULT_SIZE         (16 * MEGABYTE) // 16 MB
 
 #define PKA_MAX_QUEUES_NUM        16
-#define PKA_SHMEM_SIZE_MASK       0x0FFFFFFFUL
-#define PKA_SHMEM_NAME_SIZE       32
-#define PKA_SHMEM_PREFIX          "PKA_"
-
-// Shared memory object information
-typedef struct
-{
-    int         fd;         ///< shared memory file descriptor.
-    const char *name;       ///< shared memory mmap name.
-    size_t      size;       ///< shared memory mmap size.
-    uintptr_t   addr;       ///< shared memory address.
-    uint8_t    *ptr;        ///< shared memory pointer.
-} pka_shmem_info_t;
 
 typedef struct
 {
@@ -92,8 +79,6 @@ typedef struct
     uint32_t         rings_cnt;          ///< number of allocated Rings.
     pka_ring_info_t  rings[PKA_MAX_NUM_RINGS];    ///< table of allocated rings
                                                   ///  to process PK commands.
-
-    pka_shmem_info_t shmem_info;         ///< shared memory information.
 
     /// Lock-free implementations have higher performance and scale better
     /// than implementations using locks. User can decide whether to use


### PR DESCRIPTION
* Shared memory is needed when sharing information between processes.
  Currently no information is shared between processes of PKA library.
  However, shared memory is being used/created with the same name/id
  for every process that invokes pka_init_global() and it is done
  after performing 'unlink' of the existing shared memory(if any).
  This works for multi-processesing because the memory is only 'unlinked'
  and not free'd, therefore the process holding the pointer to 'unlinked'
  memory can still access it. This is incorrect and not reliable.
  Use heap memory instead as there is no need for shared memory.

* The 'name' parameter passed to pka_init_global() is retained as this
  might be useful for debugging purposes. Also, removing it would change the API
  making it incompatible with previous versions.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>