### PR TITLE
Mustang/BF3 changes

### DIFF
--- a/include/pka_config.h
+++ b/include/pka_config.h
@@ -37,12 +37,16 @@
 #include "pka_addrs.h"
 
 // The maximum number of PKA shims refered to as IO blocks.
-#define PKA_MAX_NUM_IO_BLOCKS           8
+#define PKA_MAX_NUM_IO_BLOCKS           24
 // The maximum number of Rings supported by IO block (shim).
 #define PKA_MAX_NUM_IO_BLOCK_RINGS      4
 
 #define PKA_MAX_NUM_RINGS \
     (PKA_MAX_NUM_IO_BLOCK_RINGS * PKA_MAX_NUM_IO_BLOCKS)
+
+// Bitmask to represent rings, grouped into 8 bit (uint8_t) blocks.
+#define PKA_RING_NUM_BITMASK \
+    ((PKA_MAX_NUM_RINGS / 8) + 1)
 
 // Resources are regions which include info control/status words,
 // count registers and host window ram.
@@ -72,7 +76,11 @@
 #define PKA_WINDOW_RAM_RING_MEM_SIZE         0x0800 //  2KB
 #define PKA_WINDOW_RAM_DATA_MEM_SIZE         0x3800 // 14KB
 
+// Window RAM/Alternate Window RAM  offset mask for BF1 and BF2
 #define PKA_WINDOW_RAM_OFFSET_MASK1       0x730000
+
+// Window RAM/Alternate Window RAM offset mask for BF3
+#define PKA_WINDOW_RAM_OFFSET_MASK2       0x70000
 
 // Macro for mapping PKA Ring address into Window RAM address. It converts the
 // ring address, either physical address or virtual address, to valid address

--- a/lib/pka.c
+++ b/lib/pka.c
@@ -267,7 +267,7 @@ pka_instance_t pka_init_global(const char *name,
                             pka_get_rings_byte_order(PKA_HANDLE_INVALID);
     ret = pka_ring_lookup(pka_gbl_info->rings, ring_cnt,
                           pka_gbl_info->rings_byte_order,
-                          &pka_gbl_info->rings_mask,
+                          pka_gbl_info->rings_mask,
                           &pka_gbl_info->rings_cnt);
     if (ret)
     {
@@ -314,8 +314,8 @@ void pka_term_global(pka_instance_t instance)
                                         "longer usable\n");
 
         PKA_DEBUG(PKA_USER, "release PKA rings\n");
-        pka_ring_free(pka_gbl_info->rings, &pka_gbl_info->rings_mask,
-                        &pka_gbl_info->rings_cnt);
+        pka_ring_free(pka_gbl_info->rings, pka_gbl_info->rings_mask,
+                      &pka_gbl_info->rings_cnt);
 
         free(pka_gbl_info);
         pka_gbl_info = NULL;
@@ -383,7 +383,7 @@ uint32_t pka_get_rings_count(pka_instance_t instance)
     return 0;
 }
 
-uint32_t pka_get_rings_bitmask(pka_instance_t instance)
+uint8_t* pka_get_rings_bitmask(pka_instance_t instance)
 {
     if (instance == (pka_instance_t) pka_gbl_info->main_pid)
         return pka_gbl_info->rings_mask;

--- a/lib/pka.h
+++ b/lib/pka.h
@@ -220,8 +220,8 @@ uint32_t pka_get_rings_count(pka_instance_t instance);
 ///
 /// @param instance     A PK instance handle.
 ///
-/// @return             The bitmask of allocated HW rings.
-uint32_t pka_get_rings_bitmask(pka_instance_t instance);
+/// @return             The bitmask(array of uint8_t) of allocated HW rings.
+uint8_t* pka_get_rings_bitmask(pka_instance_t instance);
 
 /// Thread local PKA initialization. All threads must call this function before
 /// calling any other PKA API functions. The instance parameter specifies which

--- a/lib/pka_internal.h
+++ b/lib/pka_internal.h
@@ -75,7 +75,7 @@ typedef struct
                                                   ///  thread workers.
 
     uint32_t         rings_byte_order;   ///< byte order whether BE or LE.
-    uint32_t         rings_mask;         ///< bitmask of allocated HW rings.
+    uint8_t          rings_mask[PKA_RING_NUM_BITMASK]; ///< bitmask of allocated HW rings.
     uint32_t         rings_cnt;          ///< number of allocated Rings.
     pka_ring_info_t  rings[PKA_MAX_NUM_RINGS];    ///< table of allocated rings
                                                   ///  to process PK commands.

--- a/lib/pka_ring.h
+++ b/lib/pka_ring.h
@@ -292,12 +292,12 @@ typedef struct
 int pka_ring_lookup(pka_ring_info_t rings[],
                     uint32_t        req_rings_num,
                     uint8_t         byte_order,
-                    uint32_t        *mask,
+                    uint8_t         mask[],
                     uint32_t        *cnt);
 
 /// Free a set of assigned rings, referred by their number (cnt), their mask.
 /// It returns 0 on success, a negative error code on failure.
-int pka_ring_free(pka_ring_info_t rings[], uint32_t *mask, uint32_t *cnt);
+int pka_ring_free(pka_ring_info_t rings[], uint8_t mask[], uint32_t *cnt);
 
 /// Returns the number of available of rooms to append a command descriptors
 /// within a given ring.

--- a/tests/power/pka_test_power.c
+++ b/tests/power/pka_test_power.c
@@ -928,19 +928,24 @@ static void ParseArgs(int argc, char *argv[], app_args_t *app_args)
 
 static void PrintInfo(char *progname, app_args_t *app_args)
 {
+    int8_t   mask_idx;
+    uint8_t *mask;
+
     printf("Running PKA test: %s\n"
            "--------------------------\n"
            "Avail rings          :  %d\n"
-           "HW rings in use      :  %x\n"
            "Nb of objs per queue :  %d\n"
            "RSA key size in bits :  %d\n"
            "Expected duration    :  %ds\n",
            progname,
            pka_get_rings_count(pka_instance),
-           pka_get_rings_bitmask(pka_instance),
            app_args->queue_size,
            app_args->key_size * 1024,
            app_args->duration);
+    mask = pka_get_rings_bitmask(pka_instance);
+    printf("HW rings in use      :  ");
+    for (mask_idx = PKA_RING_NUM_BITMASK - 1; mask_idx >= 0; mask_idx--)
+        printf("%x", mask[mask_idx]);
     printf("\n\n");
     fflush(NULL);
 }

--- a/tests/validation/pka_test_validation.c
+++ b/tests/validation/pka_test_validation.c
@@ -1836,6 +1836,8 @@ static void ParseArgs(int argc, char *argv[], app_args_t *app_args)
 
 static void PrintInfo(char *progname, app_args_t *app_args)
 {
+    int8_t   mask_idx;
+    uint8_t *mask;
     printf("\n"
            "PKA system info\n"
            "---------------\n"
@@ -1851,11 +1853,15 @@ static void PrintInfo(char *progname, app_args_t *app_args)
 
     printf("Running PKA inst: %s\n"
            "-----------------\n"
-           "Avail rings:      %d\n"
-           "HW rings in use:  %x\n",
+           "Avail rings:      %d\n",
            progname,
-           pka_get_rings_count(app_args->instance),
-           pka_get_rings_bitmask(app_args->instance));
+           pka_get_rings_count(app_args->instance));
+
+    mask = pka_get_rings_bitmask(app_args->instance);
+    printf("HW rings in use      :  ");
+    for (mask_idx = PKA_RING_NUM_BITMASK - 1; mask_idx >= 0; mask_idx--)
+        printf("%x", mask[mask_idx]);
+    printf("\n\n");
     printf("Mode:            ");
     switch (app_args->mode)
     {


### PR DESCRIPTION
* Number of PKA devices is now increased to 24.
  3 Clusters of 8 PKA devices each.

* The bit positions for configuration registers are also changed.
  Hence the change in window ram bitmask.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>