### PR TITLE
Enable DRBG block in TRNG

### DIFF
--- a/include/pka_addrs.h
+++ b/include/pka_addrs.h
@@ -105,6 +105,7 @@
 #define TRNG_FRODETUNE_ADDR     0x12048
 #define TRNG_ALARMMASK_ADDR     0x12050
 #define TRNG_ALARMSTOP_ADDR     0x12058
+#define TRNG_TEST_ADDR          0x120E0
 #define TRNG_BLOCKCNT_ADDR      0x120E8
 #define TRNG_OPTIONS_ADDR       0x120F0
 #define TRNG_TEST_ADDR          0x120E0
@@ -116,6 +117,19 @@
 #define TRNG_POKER_7_4          0x120C8
 #define TRNG_POKER_B_8          0x120D0
 #define TRNG_POKER_F_C          0x120D8
+
+#define TRNG_PS_AI_0_ADDR       0x12080
+#define TRNG_PS_AI_1_ADDR       0x12088
+#define TRNG_PS_AI_2_ADDR       0x12090
+#define TRNG_PS_AI_3_ADDR       0x12098
+#define TRNG_PS_AI_4_ADDR       0x120A0
+#define TRNG_PS_AI_5_ADDR       0x120A8
+#define TRNG_PS_AI_6_ADDR       0x120B0
+#define TRNG_PS_AI_7_ADDR       0x120B8
+#define TRNG_PS_AI_8_ADDR       0x120C0
+#define TRNG_PS_AI_9_ADDR       0x120C8
+#define TRNG_PS_AI_10_ADDR      0x120D0
+#define TRNG_PS_AI_11_ADDR      0x120D8
 
 // Control register address/offset. This is accessed from the ARM using 8
 // byte reads/writes however only the bottom 32 bits are implemented.

--- a/include/pka_config.h
+++ b/include/pka_config.h
@@ -182,6 +182,31 @@
 // TRNG Control bit
 #define PKA_TRNG_CONTROL_TEST_MODE          0x100
 
+// TRNG Control Register Value; Set bit 10 and 12 to start the EIP-76 a.k.a TRNG
+// engine with DRBG enabled, gathering entropy from the FROs.
+#define PKA_TRNG_CONTROL_DRBG_REG_VAL       0x00001400
+
+// DRBG enabled TRNG 'request_data' value. REQ_DATA_VAL (in accordance with
+// DATA_BLOCK_MASK) requests 256 blocks of 128-bit random output.
+// 4095 blocks is the max number that can be requested for the TRNG(with DRBG)
+// configuration on Bluefield platforms.
+#define PKA_TRNG_CONTROL_REQ_DATA_VAL       0x10010000
+
+// Mask for 'Data Block' in TRNG Control Register.
+#define PKA_TRNG_DRBG_DATA_BLOCK_MASK       0xfff00000
+
+// Set bit 12 of TRNG Control Register to enable DRBG functionality.
+#define PKA_TRNG_CONTROL_DRBG_ENABLE_VAL    0x00001000
+
+// Set bit 8 a.ka 'test_sp_800_90 DRBG' bit in the TRNG Test Register.
+#define PKA_TRNG_TEST_DRBG_VAL              0x00000080
+
+// Number of Personalization String/Additional Input Registers
+#define PKA_TRNG_PS_AI_REG_COUNT            12
+
+// DRBG Reseed enable
+#define PKA_TRNG_CONTROL_DRBG_RESEED        0x00008000
+
 // TRNG Status bits
 #define PKA_TRNG_STATUS_READY               0x1
 #define PKA_TRNG_STATUS_SHUTDOWN_OFLO       0x2


### PR DESCRIPTION
* DRBG should be enabled for FIPS compliance and also
it makes TRNG more robust due to the AES core present inside DRBG.

* DRBG should be reseeded often and currently it's configured to reseed
after generating 256 blocks of 128-bit random output.
DRBG is used in conjunction with Conditioning Functioning and without
BC_DF block. Therefore, random output is not blocked during reseed operation.

* Before using the TRNG with DRBG configured, NIST known answer test is performed
on the entire DRBG block to verify if DRBG is functioning as expected.

* Personalization string for DRBG is chosen so that it fits into the 12 registers (384 bits).

* Fix issue: 'trng_read' local variable needs to be cleared after acknowledging the random
output everytime. Else, it is always set and old random data might be used in certain cases.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>