### PR TITLE
PKA engine support for OpenSSL 3.0

### DIFF
--- a/README.engine
+++ b/README.engine
@@ -17,6 +17,14 @@ operation such as signature generation and verification.
 The BlueField PKA engine might be integrated with OpenSSL 1.0 and 1.1.
 Earlier versions may or may not work; use at your own risk!
 
+Bluefield PKA engine can also be used with OpenSSL 3.0 provided OpenSSL 3.0
+is built with compatibility for OpenSSL 1.1. This can be done by passing the
+option "--api=1.1.0" during the configure step for OpenSSL 3.0.
+Once OpenSSL 3.0 is built with compatibility for OpenSSL 1.1, follow the steps
+below on how to build, install and use the Bluefield PKA engine.
+
+Currently, OpenSSL 3.0 is in alpha release (alpha12), so it is not a stable
+release; some of the advertised features might not work!
 
 ===============================================================================
 Important Notes

--- a/engine/Makefile.am
+++ b/engine/Makefile.am
@@ -5,6 +5,7 @@ libbfengine_la_LIBADD = $(top_builddir)/lib/libPKA.la
 
 libbfengine_la_CFLAGS = \
 	-fPIC -O3 -g -Wall -Werror \
-	-I$(top_srcdir)/include -I$(top_srcdir)/lib -I$(top_srcdir)/engine/helper
+	-I$(top_srcdir)/include -I$(top_srcdir)/lib -I$(top_srcdir)/engine/helper \
+	-DOPENSSL_API_COMPAT=0x10100000L
 
 libbfengine_la_LDFLAGS = -lcrypto -version-info 2:0:1


### PR DESCRIPTION
* PKA engine can be used with OpenSSL 3.0, provided OpenSSL 3.0 is built
  with backward compatibility for OpenSSL 1.1.0.

* OpenSSL 3.0 requires definition of OPENSSL_API_COMPAT with value
 equal to version number representing the compatibility version (1.1.0, in this case as
 OpenSSL 3.0 needs to be built with OpenSSL 1.1.0 backward compatibility).
 This is required only when building OpenSSL 3.0 with backward compatibility.

* Update the internal structures for OpenSSL 3.0

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>