### PR TITLE
Add tests to check TRNG(True Random Number Generator) block

### DIFF
--- a/include/pka_addrs.h
+++ b/include/pka_addrs.h
@@ -107,6 +107,15 @@
 #define TRNG_ALARMSTOP_ADDR     0x12058
 #define TRNG_BLOCKCNT_ADDR      0x120E8
 #define TRNG_OPTIONS_ADDR       0x120F0
+#define TRNG_TEST_ADDR          0x120E0
+#define TRNG_RAW_L_ADDR         0x12060
+#define TRNG_RAW_H_ADDR         0x12068
+#define TRNG_RUN_CNT_ADDR       0x12080
+#define TRNG_MONOBITCNT_ADDR    0x120B8
+#define TRNG_POKER_3_0_ADDR     0x120C0
+#define TRNG_POKER_7_4          0x120C8
+#define TRNG_POKER_B_8          0x120D0
+#define TRNG_POKER_F_C          0x120D8
 
 // Control register address/offset. This is accessed from the ARM using 8
 // byte reads/writes however only the bottom 32 bits are implemented.

--- a/include/pka_config.h
+++ b/include/pka_config.h
@@ -178,8 +178,23 @@
 // TRNG Control Register Value; Set bit 10 to start the EIP-76 a.k.a TRNG
 // engine, gathering entropy from the FROs.
 #define PKA_TRNG_CONTROL_REG_VAL            0x00000400
+
+// TRNG Control bit
+#define PKA_TRNG_CONTROL_TEST_MODE          0x100
+
 // TRNG Status bits
 #define PKA_TRNG_STATUS_READY               0x1
 #define PKA_TRNG_STATUS_SHUTDOWN_OFLO       0x2
+#define PKA_TRNG_STATUS_TEST_READY          0x100
+#define PKA_TRNG_STATUS_MONOBIT_FAIL        0x80
+#define PKA_TRNG_STATUS_RUN_FAIL            0x10
+#define PKA_TRNG_STATUS_POKER_FAIL          0x40
+
+// TRNG Alarm Counter bits
+#define PKA_TRNG_ALARMCNT_STALL_RUN_POKER   0x8000
+
+// TRNG Test bits
+#define PKA_TRNG_TEST_KNOWN_NOISE           0x20
+#define PKA_TRNG_TEST_NOISE                 0x2000
 
 #endif // __PKA_CONFIG_H__


### PR DESCRIPTION
* Tests are required in order assess the condition of TRNG.
  Failure in these tests implies TRNG is not functioning as expected
  and hence cannot be trusted. In case of failure disable the TRNG.

* TRNG needs to be configured before running the tests and re-configured
  again after testing as TRNG wil be in an undefined state.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>