### PR TITLE
Add support for Curve 25519 and Cruve 448

### DIFF
--- a/include/pka_types.h
+++ b/include/pka_types.h
@@ -66,7 +66,8 @@ typedef enum
     PKA_RESULT_BUF_NULL         = -1516,  ///< result buf ptr is NULL
     PKA_RESULT_BUF_TOO_SMALL    = -1517,  ///< result buf_len too small
     PKA_BAD_RESULT_IDX          = -1518,  ///< bad rsult_idx
-    PKA_RESULT_FIFO_EMPTY       = -1519   ///< result fifo empty
+    PKA_RESULT_FIFO_EMPTY       = -1519,  ///< result fifo empty
+    PKA_CURVE_TYPE_INVALID      = -1520   ///< Invalid curve type
 } pka_ret_code_t;
 
 /// The pka_comparison_t enumeration is the result type for internal comparison.

--- a/lib/pka_queue.c
+++ b/lib/pka_queue.c
@@ -306,6 +306,17 @@ static uint32_t pka_operands_len(pka_opcode_t  opcode,
 
         break;
 
+    case CC_MONT_ECDH_MULTIPLY:
+        lenA = pka_operand_wlen(&operands[0], MAX_ECC_VEC_SZ);
+        lenB = pka_operand_wlen(&operands[2], MAX_ECC_VEC_SZ);
+
+        operands_wlen += PKA_ALIGN(lenA, 8);
+        operands_wlen += PKA_ALIGN(pka_concat_wlen(lenB, 3, 2, 0), 8);
+        operands_wlen += PKA_ALIGN(lenB + 3, 8);
+        operands_wlen += PKA_ALIGN(lenB, 8);
+
+        break;
+
     case CC_ECC_PT_ADD:
         lenB = MAX(pka_operand_wlen(&operands[0], MAX_ECC_VEC_SZ),
                    pka_operand_wlen(&operands[2], MAX_ECC_VEC_SZ));

--- a/lib/pka_vectors.h
+++ b/lib/pka_vectors.h
@@ -43,10 +43,10 @@
 #include "pka.h"
 #include "pka_types.h"
 
-// EIP-154 maximum operand lengths in 4-byte words:
-#define MAX_GEN_VEC_SZ         258
-#define MAX_MODEXP_CRT_VEC_SZ  130
-#define MAX_ECC_VEC_SZ          24
+// EIP-154 maximum operand lengths in bytes:
+#define MAX_GEN_VEC_SZ         (258 * 4)
+#define MAX_MODEXP_CRT_VEC_SZ  (130 * 4)
+#define MAX_ECC_VEC_SZ         ( 24 * 4)
 
 // The following maximum lengths are deliberately a little larger than the
 // actual HW limits above so as to allow for algorithms that might have


### PR DESCRIPTION
* New firmware provides support for montgomery curves 25519 and 448.
  Extend PKA library and test framework to support the same.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>