### PR TITLE
Fix OpenSSL version encapsulation

### DIFF
--- a/engine/helper/pka_helper.c
+++ b/engine/helper/pka_helper.c
@@ -173,6 +173,7 @@ static uint32_t gbl_engine_finish;
         PKA_PRINT(PKA_ENGINE, fmt_and_args);    \
 })
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
 ENGINE_PKA_KEYPAIR *engine_pka_keypair_new(int nid, int flag, int size)
 {
     ENGINE_PKA_KEYPAIR *kpair = NULL;
@@ -255,6 +256,7 @@ int engine_pka_keypair_free(ENGINE_PKA_KEYPAIR *kpair)
 
     return 1;
 }
+#endif
 
 
 static void byte_swap_copy(uint8_t *dest, uint8_t *src, uint32_t len)

--- a/engine/helper/pka_helper.h
+++ b/engine/helper/pka_helper.h
@@ -109,15 +109,6 @@ typedef struct {
     bool           valid;
 } pka_engine_info_t;
 
-struct pka_keypair {
-    pka_operand_t private_key;
-    pka_operand_t public_key;
-    int nid;
-    bool has_private;
-};
-
-typedef struct pka_keypair ENGINE_PKA_KEYPAIR;
-
 struct engine_pka_nid_data_st
 {
     const char *name;
@@ -134,6 +125,16 @@ int pka_init(void);
 // function is not thread-safe.
 int pka_finish(void);
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+struct pka_keypair {
+    pka_operand_t private_key;
+    pka_operand_t public_key;
+    int nid;
+    bool has_private;
+};
+
+typedef struct pka_keypair ENGINE_PKA_KEYPAIR;
+
 // This function allocates the memory resources required to store public and
 // private key pairs of size @size.
 // Note: @flag is currently not useful but is reserved for future when
@@ -143,6 +144,7 @@ ENGINE_PKA_KEYPAIR *engine_pka_keypair_new(int nid, int flag, int size);
 // This function releases all the memory resources allocated for
 // public and private key pair.
 int engine_pka_keypair_free(ENGINE_PKA_KEYPAIR *kpair);
+#endif
 
 // This function implements the modular exponentiation using BlueField
 // PKA hardware.


### PR DESCRIPTION
* engine_pka_keypair_new/free() functions are used only
  in case of OpenSSL >= 1.1.0. These functions make use of
  OPENSSL_secure_malloc/free() functions which are only defined
  in OpenSSL >= 1.1.0

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>