### PR TITLE
lib/pka_dev.c: NULL pointer kfree()'d in pka_dev_create_shim()

### DIFF
--- a/lib/pka_dev.c
+++ b/lib/pka_dev.c
@@ -716,7 +716,6 @@ static int pka_dev_create_shim(pka_dev_shim_t *shim, uint32_t shim_id,
     if (!shim->rings)
     {
         PKA_ERROR(PKA_DEV, "unable to kmalloc\n");
-        kfree(shim->rings);
         return -ENOMEM;
     }
 


### PR DESCRIPTION
If 'shim->rings' is NULL then the "unable to kmalloc" branch is
taken which does kfree(NULL).