### PR TITLE
[Bug Fix] OpenSSL workaround only needed in 1.1.0 for EC mode

### DIFF
--- a/engine/e_bluefield.c
+++ b/engine/e_bluefield.c
@@ -492,6 +492,9 @@ static int bind_pka(ENGINE *e)
         return 0;
     }
 
+    /* refcount is only used for EC functions */
+    refcount += 1;
+
     if (!ENGINE_set_pkey_meths(e, engine_pka_pkey_meths))
     {
         printf("ERROR: %s: Set PKEY methods failed\n", __func__);
@@ -543,8 +546,6 @@ static int bind_pka(ENGINE *e)
         return 0;
     }
 
-    refcount += 1;
-
     return 1;
 }
 
@@ -594,12 +595,14 @@ static int engine_pka_finish(ENGINE *e)
 static int engine_pka_destroy(ENGINE *e)
 {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#ifndef NO_EC
     refcount -= 1;
     if (refcount > 0)
     {
         /* Workaround OpenSSL multiple destroy bug */
         engine_pka_register_methods();
     }
+#endif
 
 #ifndef NO_RSA
     if (pka_rsa_meth)


### PR DESCRIPTION
Contain all logic for the OpenSSL workaround under OpenSSL version of at least 1.1.0, and only when EC is activated.

Signed-off-by: Eyal Itkin <eitkin@nvidia.com>