### PR TITLE
[Bug Fix] Fix errors when packaging .deb with -O3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,15 @@
 #!/usr/bin/make -f
+
+export CFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong -Wformat -Werror=format-security
+export CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2
+export CXXFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong -Wformat -Werror=format-security
+export FCFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong
+export FFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong
+export GCJFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong
+export LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro
+export OBJCFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong -Wformat -Werror=format-security
+export OBJCXXFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong -Wformat -Werror=format-security
+
 %:
 	dh $@ --with autoreconf
 


### PR DESCRIPTION
Debian packages encounter errors when compiled with "-O3" for packaging. Make sure the compilation flags will be "-O2" regardless of the compilation environment.

Signed-off-by: Eyal Itkin <eitkin@nvidia.com>