### PR TITLE
pka: Update ioremap_nocache() API to ioremap()

### DIFF
--- a/lib/pka_dev.c
+++ b/lib/pka_dev.c
@@ -239,7 +239,7 @@ static int pka_dev_set_resource_config(pka_dev_shim_t *shim,
             return -EPERM;
         }
 
-        res_ptr->ioaddr = ioremap_nocache(res_ptr->base, res_ptr->size);
+        res_ptr->ioaddr = ioremap(res_ptr->base, res_ptr->size);
     }
 
     res_ptr->status = PKA_DEV_RES_STATUS_MAPPED;


### PR DESCRIPTION
Beginning from linux kernel version 5.10, ioremap_nocache() is no
longer available. Instead use ioremap() which is present since
linux kernel version 2.6

RM #3002860

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>