### PR TITLE
Fix centos7 openssl11 segfault.

### DIFF
--- a/engine/Makefile.am
+++ b/engine/Makefile.am
@@ -8,12 +8,14 @@ libbfengine_la_CFLAGS = \
         -fPIC -O3 -g -Wall -Werror \
         -I$(top_srcdir)/include -I$(top_srcdir)/lib -I$(top_srcdir)/engine/helper \
         -DOPENSSL_API_COMPAT=0x10100000L -I/usr/include/openssl11
+libbfengine_la_LDFLAGS = \
+        -l:libcrypto.so.1.1 -version-info 2:0:1
 else
 libbfengine_la_CFLAGS = \
         -fPIC -O3 -g -Wall -Werror \
         -I$(top_srcdir)/include -I$(top_srcdir)/lib -I$(top_srcdir)/engine/helper \
         -DOPENSSL_API_COMPAT=0x10100000L
+libbfengine_la_LDFLAGS = \
+       -lcrypto -version-info 2:0:1
 endif
 
-
-libbfengine_la_LDFLAGS = -lcrypto -version-info 2:0:1

--- a/libpka.spec
+++ b/libpka.spec
@@ -26,6 +26,7 @@ PKA hardware.
 %setup
 
 %build
+./autogen.sh
 %configure
 %make_build
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,8 +7,8 @@ pka_test_validation_SOURCES = validation/pka_test_validation.c pka_test_utils.c
 pka_test_performance_SOURCES = performance/pka_test_performance.c pka_test_utils.c
 
 if OPENSSL11
-pka_test_validation_LDADD = $(top_builddir)/lib/libPKA.la -L/usr/lib64/openssl11 -lcrypto
-pka_test_performance_LDADD = $(top_builddir)/lib/libPKA.la -L/usr/lib64/openssl11 -lcrypto
+pka_test_validation_LDADD = $(top_builddir)/lib/libPKA.la -L/usr/lib64/openssl11 -l:libcrypto.so.1.1
+pka_test_performance_LDADD = $(top_builddir)/lib/libPKA.la -L/usr/lib64/openssl11 -l:libcrypto.so.1.1
 else
 pka_test_validation_LDADD = $(top_builddir)/lib/libPKA.la -lcrypto
 pka_test_performance_LDADD = $(top_builddir)/lib/libPKA.la -lcrypto


### PR DESCRIPTION
Cherry picked and squashed from master 
caf8f5f809422b79e9ac0618db26c394c34040a6
46fc04fdef7fedd7005bb9cc5f2ccf6ad851ef34

* Link to a specific version of libcrypto in engine and tests so that correct library version is used
* Run autogen before reconfigure in specfile