### PR TITLE
Return PKA test utils in bindir in deb

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,11 +6,7 @@ else
         OPENSSL_ENGINES_DIR=engines-3
 endif
 
-ifeq (,$(findstring openEuler, $(shell grep -o openEuler /etc/os-release)))
-        LIB_DIR=usr/lib/${DEB_TARGET_GNU_TYPE}
-else
-        LIB_DIR=usr/lib64
-endif
+LIB_DIR=usr/lib64
 
 export CFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong -Wformat -Werror=format-security
 export CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2
@@ -27,9 +23,6 @@ export OBJCXXFLAGS=-g -O2 -fdebug-prefix-map=/root=. -fstack-protector-strong -W
 
 override_dh_auto_install:
 	dh_auto_install
-	mkdir -p debian/libpka1/${LIB_DIR}/libpka1
-	mv debian/libpka1/usr/bin/* debian/libpka1/${LIB_DIR}/libpka1/
-	rmdir debian/libpka1/usr/bin/
 	mkdir -p debian/libpka1/usr/share/doc/libpka1/
 	mv debian/libpka1/usr/share/doc/pka/* debian/libpka1/usr/share/doc/libpka1/
 	rmdir debian/libpka1/usr/share/doc/pka/


### PR DESCRIPTION
* Do not move pka test utils to libdir in debian
* Remove openeuler condition in deb rules