### PR TITLE
pka_dev.c: remove EIP-154 hardware initialization logic

### DIFF
--- a/include/pka_addrs.h
+++ b/include/pka_addrs.h
@@ -79,15 +79,6 @@
 // from the ARM as 8 byte reads/writes however only the bottom 32 bits are
 // implemented.
 #define AIC_POL_CTRL_ADDR       0x11E00
-#define AIC_TYPE_CTRL_ADDR      0x11E08
-#define AIC_ENABLE_CTRL_ADDR    0x11E10
-#define AIC_RAW_STAT_ADDR       0x11E18
-#define AIC_ENABLE_SET_ADDR     0x11E18
-#define AIC_ENABLED_STAT_ADDR   0x11E20
-#define AIC_ACK_ADDR            0x11E20
-#define AIC_ENABLE_CLR_ADDR     0x11E28
-#define AIC_OPTIONS_ADDR        0x11E30
-#define AIC_VERSION_ADDR        0x11E38
 
 // The True Random Number Generator CSR addresses/offsets. These are accessed
 // from the ARM as 8 byte reads/writes however only the bottom 32 bits are
@@ -143,37 +134,8 @@
 #define RESULT_COUNT_0_ADDR     0x80088
 #define IRQ_THRESH_0_ADDR       0x80090
 
-// Ring 1 CSRS:
-#define COMMAND_COUNT_1_ADDR    0x90080
-#define RESULT_COUNT_1_ADDR     0x90088
-#define IRQ_THRESH_1_ADDR       0x90090
-
-// Ring 2 CSRS:
-#define COMMAND_COUNT_2_ADDR    0xA0080
-#define RESULT_COUNT_2_ADDR     0xA0088
-#define IRQ_THRESH_2_ADDR       0xA0090
-
-// Ring 3 CSRS:
-#define COMMAND_COUNT_3_ADDR    0xB0080
-#define RESULT_COUNT_3_ADDR     0xB0088
-#define IRQ_THRESH_3_ADDR       0xB0090
-
-// EIP154 RAM regions: Note that the FARM_PROG_RAM_X address range overlaps
-// with the FARM_DATA_RAM_X and FARM_DATA_RAM_X_EXT address ranges.  This
-// conflict is resolved by using the FARM_PROG_RAM_X only when the
-// Sequencer is in SW reset, and the DATA_RAMs are picked only when the
-// engine is operation.
-//
-//  Note:
-//      The FARM_DATA_RAM_X_EXT RAMs may also be
-//      called the LNME FIFO RAMs in some of the documentation.
 //
 //          PKA_BUFFER_RAM        : 1024 x 64  -  8K bytes
-//          PKA_SECURE_RAM        : 1536 x 64  - 12K bytes
-//          PKA_MASTER_PROG_RAM   : 8192 x 32  - 32K bytes
-//          FARM_DATA_RAM_X       : 1024 x 64  -  8K bytes
-//          FARM_DATA_RAM_X_EXT   :  256 x 32  -  1K bytes
-//          FARM_PROG_RAM_X       : 2048 x 32  -  8K bytes
 //
 //  Note:
 //      *TBD* Since hardware guys multiplied the address per 2, the size of
@@ -181,56 +143,9 @@
 //      Memory size should be adjusted accordingly:
 //          PKA Buffer RAM size :                8KB  --> 16KB
 //          PKA Secure RAM size :                8KB  --> 16KB
-//          PKA Master Program RAM size :       32KB  --> 64KB
-//          PKA Farm Data RAM size :             4KB  -->  8KB
-//          PKA Farm Data RAM extension size :   4KB  -->  8KB
-//          PKA Farm Program RAM size :          8KB  --> 16KB
 //
 #define PKA_BUFFER_RAM_BASE         0x00000
 #define PKA_BUFFER_RAM_SIZE         MEM_SIZE_16KB   // 0x00000...0x03FFF
-
-#define PKA_SECURE_RAM_BASE         0x20000
-#define PKA_SECURE_RAM_SIZE         MEM_SIZE_16KB   // 0x20000...0x23FFF
-
-#define PKA_MASTER_PROG_RAM_BASE    0x30000
-#define PKA_MASTER_PROG_RAM_SIZE    MEM_SIZE_64KB   // 0x30000...0x3FFFF
-
-#define FARM_DATA_RAM_0_BASE        0x40000
-#define FARM_DATA_RAM_0_SIZE        MEM_SIZE_8KB    // 0x40000...0x41FFF
-#define FARM_DATA_RAM_0_EXT_BASE    0x42000
-#define FARM_DATA_RAM_0_EXT_SIZE    MEM_SIZE_8KB    // 0x42000...0x43FFF
-#define FARM_PROG_RAM_0_BASE        0x40000
-#define FARM_PROG_RAM_0_SIZE        MEM_SIZE_16KB   // 0x40000...0x43FFF
-#define FARM_DATA_RAM_1_BASE        0x44000
-#define FARM_DATA_RAM_1_SIZE        MEM_SIZE_8KB    // 0x44000...0x45FFF
-#define FARM_DATA_RAM_1_EXT_BASE    0x46000
-#define FARM_DATA_RAM_1_EXT_SIZE    MEM_SIZE_8KB    // 0x46000...0x47FFF
-#define FARM_PROG_RAM_1_BASE        0x44000
-#define FARM_PROG_RAM_1_SIZE        MEM_SIZE_16KB   // 0x44000...0x47FFF
-#define FARM_DATA_RAM_2_BASE        0x48000
-#define FARM_DATA_RAM_2_SIZE        MEM_SIZE_8KB    // 0x48000...0x49FFF
-#define FARM_DATA_RAM_2_EXT_BASE    0x4A000
-#define FARM_DATA_RAM_2_EXT_SIZE    MEM_SIZE_8KB    // 0x4A000...0x4BFFF
-#define FARM_PROG_RAM_2_BASE        0x48000
-#define FARM_PROG_RAM_2_SIZE        MEM_SIZE_16KB   // 0x48000...0x4BFFF
-#define FARM_DATA_RAM_3_BASE        0x4C000
-#define FARM_DATA_RAM_3_SIZE        MEM_SIZE_8KB    // 0x4C000...0x4DFFF
-#define FARM_DATA_RAM_3_EXT_BASE    0x4E000
-#define FARM_DATA_RAM_3_EXT_SIZE    MEM_SIZE_8KB    // 0x4E000...0x4FFFF
-#define FARM_PROG_RAM_3_BASE        0x4C000
-#define FARM_PROG_RAM_3_SIZE        MEM_SIZE_16KB   // 0x4C000...0x4FFFF
-#define FARM_DATA_RAM_4_BASE        0x50000
-#define FARM_DATA_RAM_4_SIZE        MEM_SIZE_8KB    // 0x50000...0x51FFF
-#define FARM_DATA_RAM_4_EXT_BASE    0x52000
-#define FARM_DATA_RAM_4_EXT_SIZE    MEM_SIZE_8KB    // 0x52000...0x53FFF
-#define FARM_PROG_RAM_4_BASE        0x50000
-#define FARM_PROG_RAM_4_SIZE        MEM_SIZE_16KB   // 0x50000...0x53FFF
-#define FARM_DATA_RAM_5_BASE        0x54000
-#define FARM_DATA_RAM_5_SIZE        MEM_SIZE_8KB    // 0x54000...0x55FFF
-#define FARM_DATA_RAM_5_EXT_BASE    0x56000
-#define FARM_DATA_RAM_5_EXT_SIZE    MEM_SIZE_8KB    // 0x56000...0x57FFF
-#define FARM_PROG_RAM_5_BASE        0x54000
-#define FARM_PROG_RAM_5_SIZE        MEM_SIZE_16KB   // 0x54000...0x57FFF
 
 // PKA Buffer RAM offsets. These are NOT real CSR's but instead are
 // specific offset/addresses within the EIP154 PKA_BUFFER_RAM.
@@ -242,27 +157,6 @@
 #define RING_RW_PTRS_0_ADDR     0x00028
 #define RING_RW_STAT_0_ADDR     0x00030
 
-// Ring 1
-#define RING_CMMD_BASE_1_ADDR   0x00040
-#define RING_RSLT_BASE_1_ADDR   0x00050
-#define RING_SIZE_TYPE_1_ADDR   0x00060
-#define RING_RW_PTRS_1_ADDR     0x00068
-#define RING_RW_STAT_1_ADDR     0x00070
-
-// Ring 2
-#define RING_CMMD_BASE_2_ADDR   0x00080
-#define RING_RSLT_BASE_2_ADDR   0x00090
-#define RING_SIZE_TYPE_2_ADDR   0x000A0
-#define RING_RW_PTRS_2_ADDR     0x000A8
-#define RING_RW_STAT_2_ADDR     0x000B0
-
-// Ring 3
-#define RING_CMMD_BASE_3_ADDR   0x000C0
-#define RING_RSLT_BASE_3_ADDR   0x000D0
-#define RING_SIZE_TYPE_3_ADDR   0x000E0
-#define RING_RW_PTRS_3_ADDR     0x000E8
-#define RING_RW_STAT_3_ADDR     0x000F0
-
 // Ring Options
 #define PKA_RING_OPTIONS_ADDR   0x07FF8
 
@@ -273,12 +167,5 @@
 // The PKI (not EIP154) CSR address/offsets: These are all addressed as
 // 8-byte registers.
 #define PKA_INT_MASK_ADDR           0x00
-#define PKA_INT_MASK_SET_ADDR       0x08
-#define PKA_INT_MASK_RESET_ADDR     0x10
-#define PKA_ZEROIZE_ADDR            0x40
-#define TST_FRO_ADDR                0x50
-#define FRO_COUNT_ADDR              0x58
-#define PKA_PARITY_CTL_ADDR         0x60
-#define PKA_PARITY_STAT_ADDR        0x68
 
 #endif // __PKA_ADDRS_H__

--- a/include/pka_config.h
+++ b/include/pka_config.h
@@ -102,38 +102,6 @@
 //  bit is write-only and self clearing and can only be set if the ‘Reset’
 //  bit [31] is ‘1’.
 #define PKA_MASTER_SEQ_CTRL_CLEAR_COUNTERS_VAL  0x40000000
-//  Bit [8] in the PKA Master Sequencer Control/Status Register is tied to
-//  the 'pka_master_irq interrupt' on the EIP-154 interrupt controller.
-#define PKA_MASTER_SEQ_CTRL_MASTER_IRQ_BIT      8
-//  Sequencer status bits are used by the Master controller Sequencer to
-//  reflect status. Bit [0] is tied to the 'pka_master_irq' interrupt on
-//  the EIP-154 interrupt controller.
-#define PKA_MASTER_SEQ_CTRL_STATUS_BYTE         0x01
-// 'pka_master_irq' mask for the Master controller Sequencer Status Register.
-#define PKA_MASTER_SEQ_CTRL_MASTER_IRQ_MASK     0x100
-
-// Advanced Interrupt Controller (AIC) configuration
-//  AIC Polarity Control Register is used to set each individual interrupt
-//  signal (High Level / Rising Edge) during the initialization phase.
-//   '0' = Low level or falling edge.
-//   '1' = High level or rising edge.
-#define PKA_AIC_POL_CTRL_REG_VAL                0x000FFFFF
-//  AIC Type Control Register is used to set each interrupt to level or edge.
-//   '0' = Level.
-//   '1' = Edge.
-#define PKA_AIC_TYPE_CTRL_REG_VAL               0x000FFFFF
-//  AIC Enable Control Register is used to enable interrupt inputs.
-//   '0' = Disabled.
-//   '1' = Enabled.
-#define PKA_AIC_ENABLE_CTRL_REG_VAL             0x000F030F
-//  AIC Enabled Status Register bits reflect the status of the interrupts
-//  gated with the enable bits of the AIC_ENABLE_CTRL Register.
-//   '0' = Inactive.
-//   '1' = Pending.
-#define PKA_AIC_ENABLE_STAT_REG_VAL             0x000F030F
-
-// 'pka_master_irq' mask for the AIC Enabled Status Register.
-#define PKA_AIC_ENABLED_STAT_MASTER_IRQ_MASK    0x100
 
 // PKA_RING_OPTIONS field to specify the priority in which rings are handled:
 //  '00' = full rotating priority,

--- a/lib/pka_dev.c
+++ b/lib/pka_dev.c
@@ -731,12 +731,6 @@ static int pka_dev_create_shim(pka_dev_shim_t *shim, uint32_t shim_id,
         return ret;
     }
 
-    // Set PKA device Master Program RAM config
-    ret = pka_dev_set_resource_config(shim, &shim->resources.master_prog_ram,
-                                      PKA_MASTER_PROG_RAM_BASE,
-                                      PKA_MASTER_PROG_RAM_SIZE,
-                                      PKA_DEV_RES_TYPE_MEM,
-                                      "PKA_MASTER_PROG_RAM");
     if (ret)
     {
         PKA_ERROR(PKA_DEV, "unable to set Master Program RAM config\n");
@@ -786,20 +780,6 @@ static int pka_dev_create_shim(pka_dev_shim_t *shim, uint32_t shim_id,
         return ret;
     }
 
-    // Set PKA device 'glue' logic registers
-    reg_size = PAGE_SIZE;
-    reg_base = pka_dev_get_register_base(shim->mem_res.csr_base,
-                                         PKA_INT_MASK_ADDR);
-    ret = pka_dev_set_resource_config(shim, &shim->resources.ext_csr,
-                                      reg_base, reg_size,
-                                      PKA_DEV_RES_TYPE_REG,
-                                      "PKA_EXT_CSR");
-    if (ret)
-    {
-        PKA_ERROR(PKA_DEV, "unable to setup the MiCA specific registers\n");
-        return ret;
-    }
-
     shim->status = PKA_SHIM_STATUS_CREATED;
 
     return ret;
@@ -809,7 +789,7 @@ static int pka_dev_create_shim(pka_dev_shim_t *shim, uint32_t shim_id,
 static int pka_dev_delete_shim(pka_dev_shim_t *shim)
 {
     int ret = 0;
-    pka_dev_res_t *res_buffer_ram, *res_master_prog_ram;
+    pka_dev_res_t *res_buffer_ram;
     pka_dev_res_t *res_master_seq_ctrl, *res_aic_csr, *res_trng_csr;
 
     PKA_DEBUG(PKA_DEV, "PKA device delete shim\n");
@@ -825,13 +805,11 @@ static int pka_dev_delete_shim(pka_dev_shim_t *shim)
     }
 
     res_buffer_ram      = &shim->resources.buffer_ram;
-    res_master_prog_ram = &shim->resources.master_prog_ram;
     res_master_seq_ctrl = &shim->resources.master_seq_ctrl;
     res_aic_csr         = &shim->resources.aic_csr;
     res_trng_csr        = &shim->resources.trng_csr;
 
     pka_dev_unset_resource_config(shim, res_buffer_ram);
-    pka_dev_unset_resource_config(shim, res_master_prog_ram);
     pka_dev_unset_resource_config(shim, res_master_seq_ctrl);
     pka_dev_unset_resource_config(shim, res_aic_csr);
     pka_dev_unset_resource_config(shim, res_trng_csr);
@@ -839,228 +817,6 @@ static int pka_dev_delete_shim(pka_dev_shim_t *shim)
     kfree(shim->rings);
 
     shim->status = PKA_SHIM_STATUS_UNDEFINED;
-
-    return ret;
-}
-
-static int pka_dev_config_aic_interrupts(pka_dev_res_t *aic_csr_ptr)
-{
-    int ret = 0;
-
-    uint64_t  csr_reg_base, csr_reg_off;
-    void     *csr_reg_ptr;
-
-    if (aic_csr_ptr->status != PKA_DEV_RES_STATUS_MAPPED ||
-            aic_csr_ptr->type != PKA_DEV_RES_TYPE_REG)
-        return -EPERM;
-
-    PKA_DEBUG(PKA_DEV, "configure the AIC so that all interrupts "
-                "are properly recognized\n");
-
-    csr_reg_base = aic_csr_ptr->base;
-    csr_reg_ptr  = aic_csr_ptr->ioaddr;
-
-    // Configure the signal polarity for each interrupt.
-    csr_reg_off =
-            pka_dev_get_register_offset(csr_reg_base, AIC_POL_CTRL_ADDR);
-    pka_dev_io_write(csr_reg_ptr, csr_reg_off, PKA_AIC_POL_CTRL_REG_VAL);
-
-    // Configure the signal type for each interrupt
-    csr_reg_off =
-            pka_dev_get_register_offset(csr_reg_base, AIC_TYPE_CTRL_ADDR);
-    pka_dev_io_write(csr_reg_ptr, csr_reg_off, PKA_AIC_TYPE_CTRL_REG_VAL);
-
-    // Set the enable control register
-    csr_reg_off =
-            pka_dev_get_register_offset(csr_reg_base, AIC_ENABLE_CTRL_ADDR);
-    pka_dev_io_write(csr_reg_ptr, csr_reg_off, PKA_AIC_ENABLE_CTRL_REG_VAL);
-
-    // Set the enabled status register
-    csr_reg_off =
-            pka_dev_get_register_offset(csr_reg_base, AIC_ENABLED_STAT_ADDR);
-    pka_dev_io_write(csr_reg_ptr, csr_reg_off, PKA_AIC_ENABLE_STAT_REG_VAL);
-
-    // *TBD* Write PKA_INT_MASK_RESET with 1's for each interrupt bit
-    // to allow them to propagate out the interrupt controller.
-    // EIP-154 interrupts can still be programmed and observed via polling
-    // regardless of whether PKA_INT_MASK is masking out the interrupts or
-    // not. The mask is for system propagation, i.e. propagate to the GIC.
-    // Bit positions are as follows:
-    //  Bit  10   - parity_error_irq (non EIP-154 interrupt)
-    //  Bit   9   - trng_irq
-    //  Bit   8   - pka_master_irq
-    //  Bits  7:4 - pka_queue_*_result_irq
-    //  Bits  3:0 - pka_queue_*_empty_irq
-
-    return ret;
-}
-
-static int pka_dev_load_image(pka_dev_res_t *res_ptr, const uint32_t *data_buf,
-                                    uint32_t size)
-{
-    uint64_t data_rd;
-    int      mismatches;
-    int      i, j, ret = 0;
-
-    if (res_ptr->status != PKA_DEV_RES_STATUS_MAPPED ||
-            res_ptr->type != PKA_DEV_RES_TYPE_MEM)
-        return -EPERM;
-
-    // Note that the image size is in word of 4 bytes and memory 'writes'
-    // are 8 bytes aligned, thus the memory start address and end address
-    // are shifted.
-    if (res_ptr->size < (size * BYTES_PER_WORD) << 1)
-    {
-        PKA_ERROR(PKA_DEV, "image size greater than memory size\n");
-        return -EINVAL;
-    }
-
-    for (i = 0, j = 0; i < size; i++, j += BYTES_PER_DOUBLE_WORD)
-        pka_dev_io_write(res_ptr->ioaddr, j,
-                            (uint64_t) data_buf[i]);
-
-    mismatches = 0;
-    PKA_DEBUG(PKA_DEV, "PKA DEV: verifying image (%u words)\n", size);
-    for (i = 0, j = 0; i < size; i++, j += BYTES_PER_DOUBLE_WORD)
-    {
-        data_rd = pka_dev_io_read(res_ptr->ioaddr, j);
-        if (data_rd != (uint64_t) data_buf[i])
-        {
-            mismatches += 1;
-            PKA_DEBUG(PKA_DEV, "error while loading image: "
-                    "addr:0x%llx expected data: 0x%x actual data: 0x%llx\n",
-                    res_ptr->base + j,
-                    data_buf[i], data_rd);
-        }
-    }
-
-    if (mismatches > 0)
-    {
-        PKA_PANIC(PKA_DEV, "error while loading image: mismatches: %d\n",
-                        mismatches);
-        return -EAGAIN;
-    }
-
-    return ret;
-}
-
-static int
-pka_dev_config_master_seq_controller(pka_dev_shim_t *shim,
-                                     pka_dev_res_t *master_seq_ctrl_ptr)
-{
-    pka_dev_res_t  *aic_csr_ptr, *master_prog_ram;
-    void           *aic_reg_ptr, *master_reg_ptr;
-
-    uint64_t        aic_reg_base, aic_reg_off;
-    uint64_t        master_reg_base, master_reg_off;
-
-    const uint32_t *boot_img_ptr, *master_img_ptr;
-    uint32_t        boot_img_size, master_img_size;
-
-    uint32_t        pka_master_irq;
-
-    uint64_t        timer;
-    uint8_t         status_bits;
-    uint8_t         shim_fw_id;
-    int             ret = 0;
-
-    if (master_seq_ctrl_ptr->status != PKA_DEV_RES_STATUS_MAPPED ||
-            master_seq_ctrl_ptr->type != PKA_DEV_RES_TYPE_REG)
-        return -EPERM;
-
-    master_reg_base = master_seq_ctrl_ptr->base;
-    master_reg_ptr  = master_seq_ctrl_ptr->ioaddr;
-    master_reg_off  = pka_dev_get_register_offset(master_reg_base,
-                                                    PKA_MASTER_SEQ_CTRL_ADDR);
-
-    PKA_DEBUG(PKA_DEV, "push the EIP-154 master controller into reset\n");
-    pka_dev_io_write(master_reg_ptr, master_reg_off,
-                            PKA_MASTER_SEQ_CTRL_RESET_VAL);
-
-    shim_fw_id = pka_firmware_get_id();
-
-    // Load boot image into PKA_MASTER_PROG_RAM
-    boot_img_size = pka_firmware_array[shim_fw_id].boot_img_size;
-    PKA_DEBUG(PKA_DEV, "loading boot image (%d words)\n", boot_img_size);
-
-    boot_img_ptr = pka_firmware_array[shim_fw_id].boot_img;
-    ret = pka_dev_load_image(&shim->resources.master_prog_ram,
-                                boot_img_ptr, boot_img_size);
-    if (ret)
-    {
-        PKA_ERROR(PKA_DEV, "failed to load boot image\n");
-        return ret;
-    }
-
-    PKA_DEBUG(PKA_DEV, "take the EIP-154 master controller out of reset\n");
-    pka_dev_io_write(master_reg_ptr, master_reg_off, 0);
-
-    // Poll for 'pka_master_irq' bit in AIC_ENABLED_STAT register to indicate
-    // sequencer is initialized
-    aic_csr_ptr = &shim->resources.aic_csr;
-    if (aic_csr_ptr->status != PKA_DEV_RES_STATUS_MAPPED ||
-            aic_csr_ptr->type != PKA_DEV_RES_TYPE_REG)
-        return -EPERM;
-
-    aic_reg_base = aic_csr_ptr->base;
-    aic_reg_ptr  = aic_csr_ptr->ioaddr;
-    aic_reg_off  = pka_dev_get_register_offset(aic_reg_base,
-                                                AIC_ENABLED_STAT_ADDR);
-
-    pka_master_irq = 0;
-    PKA_DEBUG(PKA_DEV, "poll for 'pka_master_irq'\n");
-    timer = pka_dev_timer_start(100000);       // 100 msec
-    while (pka_master_irq == 0)
-    {
-        pka_master_irq |= pka_dev_io_read(aic_reg_ptr, aic_reg_off)
-                                & PKA_AIC_ENABLED_STAT_MASTER_IRQ_MASK;
-        if (pka_dev_timer_done(timer))
-        {
-            //PKA_PANIC(PKA_DEV, "failed to load firmware\n");
-            return -EAGAIN;
-        }
-    }
-    PKA_DEBUG(PKA_DEV, "'pka_master_irq' is active\n");
-
-    // Verify that the EIP-154 boot firmware has finished without errors
-    status_bits = (uint8_t)((pka_dev_io_read(master_reg_ptr,
-                        master_reg_off) >> PKA_MASTER_SEQ_CTRL_MASTER_IRQ_BIT)
-                        & 0xff);
-    if (status_bits != PKA_MASTER_SEQ_CTRL_STATUS_BYTE)
-    {
-        // If the error indication (bit [15]) is set,
-        // the EIP-154 boot firmware encountered an error and is stopped.
-        if ((status_bits >> (PKA_MASTER_SEQ_CTRL_MASTER_IRQ_BIT - 1)) == 1)
-        {
-            PKA_ERROR(PKA_DEV,
-                "boot firmware encountered an error 0x%x and is stopped\n",
-                 status_bits);
-            return -EAGAIN;
-        }
-        PKA_DEBUG(PKA_DEV, "boot firmware in progress %d", status_bits);
-    }
-    PKA_DEBUG(PKA_DEV, "boot firmware has finished successfully\n");
-
-    PKA_DEBUG(PKA_DEV, "push the EIP-154 master controller into reset\n");
-    pka_dev_io_write(master_reg_ptr, master_reg_off,
-                        PKA_MASTER_SEQ_CTRL_RESET_VAL);
-
-    // Load Master image into PKA_MASTER_PROG_RAM
-    master_img_size = pka_firmware_array[shim_fw_id].master_img_size;
-    PKA_DEBUG(PKA_DEV, "loading master image (%d words)\n",
-                master_img_size);
-    master_prog_ram = &shim->resources.master_prog_ram;
-    master_img_ptr = pka_firmware_array[shim_fw_id].master_img;
-    ret = pka_dev_load_image(master_prog_ram, master_img_ptr,
-                                master_img_size);
-    if (ret)
-    {
-        pr_err("PKA DEV: failed to load master image\n");
-        return ret;
-    }
-
-    PKA_DEBUG(PKA_DEV, "take the EIP-154 master controller out of reset\n");
-    pka_dev_io_write(master_reg_ptr, master_reg_off, 0);
 
     return ret;
 }
@@ -1706,45 +1462,6 @@ static int pka_dev_config_trng_drbg(pka_dev_res_t *aic_csr_ptr,
     return ret;
 }
 
-// Triggers hardaware zeorize to initialize PKA internal memories
-static int pka_dev_ram_zeroize(pka_dev_res_t *ext_csr_ptr)
-{
-    uint64_t  csr_reg_base, csr_reg_off, csr_reg_value;
-    uint64_t  timer;
-    void     *csr_reg_ptr;
-
-    if (ext_csr_ptr->status != PKA_DEV_RES_STATUS_MAPPED ||
-            ext_csr_ptr->type != PKA_DEV_RES_TYPE_REG)
-        return -EPERM;
-
-    PKA_DEBUG(PKA_DEV, "Starting memory zeroize\n");
-
-    csr_reg_base = ext_csr_ptr->base;
-    csr_reg_ptr  = ext_csr_ptr->ioaddr;
-
-    csr_reg_off = pka_dev_get_register_offset(csr_reg_base,
-                                              PKA_ZEROIZE_ADDR);
-    // When PKA_ZEROIZE register is written (with any value)
-    // sensitive data in the PKA is zeroed out.
-    pka_dev_io_write(csr_reg_ptr, csr_reg_off, 1);
-
-    // Now wait until the zeroize completes
-    timer = pka_dev_timer_start(10000000); // 10000 ms
-    csr_reg_value = pka_dev_io_read(csr_reg_ptr, csr_reg_off);
-    while (csr_reg_value != 0)
-    {
-        csr_reg_value = pka_dev_io_read(csr_reg_ptr, csr_reg_off);
-
-        if (pka_dev_timer_done(timer))
-        {
-            PKA_DEBUG(PKA_DEV, "Timeout while PKA zeorize\n");
-            return -EBUSY;
-        }
-    }
-
-    return 0;
-}
-
 // Initialize PKA IO block refered to as shim. It configures shim's
 // parameters and prepare resources by mapping corresponding memory.
 // The function also configures shim registers and load firmware to
@@ -1752,64 +1469,13 @@ static int pka_dev_ram_zeroize(pka_dev_res_t *ext_csr_ptr)
 // output. It returns 0 on success, a negative error code on failure.
 static int pka_dev_init_shim(pka_dev_shim_t *shim)
 {
-    const uint32_t *farm_img_ptr;
-    uint32_t        farm_img_size, data[4], i;
-    uint8_t         shim_fw_id;
-
-    int ret = 0;
+    uint32_t data[4], i;
+    int      ret = 0;
 
     if (shim->status != PKA_SHIM_STATUS_CREATED)
     {
         PKA_ERROR(PKA_DEV, "PKA device must be created\n");
         return -EPERM;
-    }
-
-    // First of all, trigger a hardware zeroize to initialize internal
-    // RAM memories
-    ret = pka_dev_ram_zeroize(&shim->resources.ext_csr);
-    if (ret)
-    {
-        PKA_ERROR(PKA_DEV, "failed to zeroize PKA\n");
-        return ret;
-    }
-
-    // Configure AIC registers
-    ret = pka_dev_config_aic_interrupts(&shim->resources.aic_csr);
-    if (ret)
-    {
-        PKA_ERROR(PKA_DEV, "failed to configure AIC\n");
-        return ret;
-    }
-
-    shim_fw_id = pka_firmware_get_id();
-
-    // Load Farm image into PKA_BUFFER_RAM for non-High Assurance mode
-    // or into PKA_SECURE_RAM for High Assurance mode.
-    farm_img_size = pka_firmware_array[shim_fw_id].farm_img_size;
-    PKA_DEBUG(PKA_DEV, "loading farm image (%d words)\n", farm_img_size);
-
-    farm_img_ptr = pka_firmware_array[shim_fw_id].farm_img;
-    // The IP provider suggests using the zeroize function to initialize
-    // the Buffer RAM. But a bug has been detected when writing ECC bits.
-    // Thus a workaround is used, and has already been shown to work; it
-    // consists of padding the farm image. Then all RAM locations will be
-    // written with correct ECC before the IP reads the image out.
-    ret = pka_dev_load_image(&shim->resources.buffer_ram, farm_img_ptr,
-                                farm_img_size);
-    if (ret)
-    {
-        PKA_ERROR(PKA_DEV, "failed to load farm image\n");
-        return ret;
-    }
-
-    // Configure EIP-154 Master controller Sequencer
-    ret = pka_dev_config_master_seq_controller(shim,
-                                        &shim->resources.master_seq_ctrl);
-    if (ret)
-    {
-        PKA_ERROR(PKA_DEV, "failed to configure Master controller "
-                                    "Sequencer\n");
-        return ret;
     }
 
     // Configure PKA Ring options control word

--- a/lib/pka_dev.h
+++ b/lib/pka_dev.h
@@ -148,11 +148,9 @@ typedef struct
 typedef struct
 {
     pka_dev_res_t    buffer_ram;        // buffer RAM
-    pka_dev_res_t    master_prog_ram;   // master controller program RAM
     pka_dev_res_t    master_seq_ctrl;   // master sequencer controller CSR
     pka_dev_res_t    aic_csr;           // interrupt controller CSRs
     pka_dev_res_t    trng_csr;          // TRNG module CSRs
-    pka_dev_res_t    ext_csr;           // MiCA specific CSRs (glue logic)
 } pka_dev_shim_res_t;
 
 #define PKA_DEV_SHIM_RES_CNT         6  // Number of PKA device resources


### PR DESCRIPTION
This update removes the EIP-154 hardware initialization logic that has been executed in the UEFI PKA DXE driver.

RM #3835266