### PR TITLE
Fix build when openssl engine disabled.

### DIFF
--- a/README.build
+++ b/README.build
@@ -134,9 +134,9 @@ How to build
     load and run OpenSSL applications with BlueField PKA engine.
 
     By default, engine support is enabled, run 'configure' script with
-    option '--without-libcrypto' to disable it:
+    option '--disable-engine' to disable it:
 
-        # ./configure --without-libcrypto
+        # ./configure --disable-engine
 
 ===============================================================================
 Building packages

--- a/configure.ac
+++ b/configure.ac
@@ -52,23 +52,26 @@ AS_IF([test x"$enable_testutils" != x"no"],
     [ENABLED_SUBDIRS="$ENABLED_SUBDIRS tests"]
 )
 
-dnl Checks if need to enable openssl pka engine
 AC_ARG_WITH([libcrypto],
-    [AS_HELP_STRING([--with-libcrypto], [Build PKA openssl engine if libcrypto is present and have version no less than 1.1. This requires pkg-config program and pc file for libcrypto (Default: libcrypto)])],
+    [AS_HELP_STRING([--with-libcrypto], [Use specific libcrypto library. Must be at least version 1.1. Library search is done using pkg-config. (Default: libcrypto)])],
     [],
     [with_libcrypto=libcrypto])
 
-AS_IF([test x"$with_libcrypto" != x"no"],
-    [PKG_CHECK_MODULES([LIBCRYPTO],
-        ["$with_libcrypto" >= 1.1.0],[],
-        [AC_MSG_ERROR([libcrypto library is either not found or its version less than 1.1 (to disable use --without-libcrypto)])]
-    )
-    ENABLED_SUBDIRS="$ENABLED_SUBDIRS engine"
-    cryptoenginesdir=$($PKG_CONFIG --variable=enginesdir --silence-errors $with_libcrypto)
+PKG_CHECK_MODULES([LIBCRYPTO],
+    ["$with_libcrypto" >= 1.1.0],[],
+    [AC_MSG_ERROR([libcrypto library is either not found or its version less than 1.1])])
 
+dnl Checks if need to enable openssl pka engine
+AC_ARG_ENABLE([engine],
+    [AS_HELP_STRING([--disable-engine], [Build PKA openssl engine (Default: yes)])],
+    [],
+    [enable_engine=yes])
+
+AS_IF([test x"$enable_engine" != x"no"],
+    [ENABLED_SUBDIRS="$ENABLED_SUBDIRS engine"
+
+    cryptoenginesdir=$($PKG_CONFIG --variable=enginesdir --silence-errors $with_libcrypto)
     AC_SUBST([cryptoenginesdir])
-    AC_SUBST([LIBCRYPTO_CFLAGS])
-    AC_SUBST([LIBCRYPTO_LIBS])
     ]
 )
 


### PR DESCRIPTION
Libpka depends on libcrypto and passing --without-libcrypto results in error. This patch makes libcrypto mandratory but allows to pass --with-libcrypto to select specific library version (mainly for centos7 with openssl11)

Returns --disable-engine flags. It does what it used to do - disabled openssl engine build