### PR TITLE
fix array bounds compile error

### DIFF
--- a/tests/validation/pka_test_validation.c
+++ b/tests/validation/pka_test_validation.c
@@ -872,7 +872,7 @@ static void ShiftTest(thread_args_t *args,
     rc = fcn(args->handle, args->user_data, operand, shift_cnt);
     if (rc != RC_NO_ERROR)
     {
-        CmdFailed(args, __func__, pki_fcn_name, &operand, 2, rc);
+        CmdFailed(args, __func__, pki_fcn_name, &operand, 1, rc);
         return;
     }
 


### PR DESCRIPTION
Newer complier treats warnings as errors and found an array bounds issue.