### PR TITLE
Patches to support backward compatibility with PKA device name path and ioctl.

### DIFF
--- a/lib/pka.c
+++ b/lib/pka.c
@@ -22,6 +22,7 @@
 #include "pka_utils.h"
 #include "pka_vectors.h"
 #include "pka_mem.h"
+#include "pka_ioctl.h"
 
 #define PKA_INVALID_OPERANDS    0x0
 
@@ -2570,7 +2571,7 @@ int pka_get_rand_bytes(pka_handle_t  handle,
         if (!ring_info)
             continue;
 
-        ret = ioctl(ring_info->fd, PKA_GET_RANDOM_BYTES, &trng_info);
+        ret = PKA_IOCTL_GET_RANDOM_BYTES(ring_info->fd, &trng_info);
         if (!ret)
             return buf_len;
 

--- a/lib/pka_dev.c
+++ b/lib/pka_dev.c
@@ -19,6 +19,7 @@
 #endif
 
 #include "pka_dev.h"
+#include "pka_ioctl.h"
 
 #ifdef __KERNEL__
 
@@ -2337,7 +2338,7 @@ int pka_dev_get_ring_info(pka_ring_info_t *ring_info)
         return -EINVAL;
 
     // Get ring parameters
-    ret = ioctl(ring_info->fd, PKA_GET_RING_INFO, &hw_ring_info);
+    ret = PKA_IOCTL_GET_RING_INFO(ring_info->fd, &hw_ring_info);
     if (ret)
     {
         PKA_ERROR(PKA_DEV, "failed to get ring information\n");
@@ -2754,7 +2755,7 @@ int pka_dev_mmap_ring(pka_ring_info_t *ring_info)
         return -EINVAL;
 
     // Get ring region information
-    ret = ioctl(ring_info->fd, PKA_RING_GET_REGION_INFO, &region_info);
+    ret = PKA_IOCTL_GET_REGION_INFO(ring_info->fd, &region_info);
     if (ret)
     {
         PKA_ERROR(PKA_DEV, "failed to get ring region info\n");

--- a/lib/pka_dev.c
+++ b/lib/pka_dev.c
@@ -2636,12 +2636,20 @@ static int pka_dev_open_ring_file(pka_ring_info_t *ring_info)
     // Invalidate the group
     ring_info->group = -EINVAL;
 
+    // First try the PKA device file name with mlxbf_ prefix
     snprintf(file, sizeof(file), PKA_DEVFS_RING_DEVICES, ring_info->ring_id);
     ring_info->fd = open(file, O_RDWR);
     if (ring_info->fd < 0)
-        PKA_DEBUG(PKA_DEV,
-                  "cannot open the PKA ring %d\n",
-                    ring_info->ring_id);
+    {
+        // Try the PKA device file name without prefix
+        snprintf(file, sizeof(file), PKA_DEVFS_RING_DEVICES_DEPRECATED, ring_info->ring_id);
+        ring_info->fd = open(file, O_RDWR);
+        if (ring_info->fd < 0)
+            PKA_DEBUG(PKA_DEV,
+                      "cannot open the PKA ring %d\n",
+                      ring_info->ring_id);
+    }
+
     return ring_info->fd;
 }
 #endif

--- a/lib/pka_dev.h
+++ b/lib/pka_dev.h
@@ -33,7 +33,8 @@
 #define PKA_VFIO_CONTAINER_PATH     "/dev/vfio/vfio"
 #define PKA_VFIO_GROUP_FMT          "/dev/vfio/%d"
 
-#define PKA_DEVFS_RING_DEVICES      "/dev/pka/%d"
+#define PKA_DEVFS_RING_DEVICES      "/dev/mlxbf_pka/%d"
+#define PKA_DEVFS_RING_DEVICES_DEPRECATED "/dev/pka/%d"
 
 // Defines specific to device-tree and Linux operating system.
 // Careful, all constants MUST be conform with both devicetree

--- a/lib/pka_ring.c
+++ b/lib/pka_ring.c
@@ -7,6 +7,7 @@
 #include "pka_ring.h"
 #include "pka_mem.h"
 #include "pka_dev.h"
+#include "pka_ioctl.h"
 
 #include "pka_utils.h"
 
@@ -80,7 +81,7 @@ static bool pka_ring_has_nonzero_counters(pka_ring_info_t *ring)
         PKA_DEBUG(PKA_RING, "non-zero HW counters - reinit PK block\n");
 
         // reset all command and result counters.
-        if (ioctl(ring->fd, PKA_CLEAR_RING_COUNTERS))
+        if (PKA_IOCTL_CLEAR_RING_COUNTERS(ring->fd))
             PKA_ERROR(PKA_RING,
                 "failed to clear non-zero CMMD_CTR_INC_x and RSLT_CTR_DEC_x\n");
 


### PR DESCRIPTION
Please check the commit message of each patch for details.