### PR TITLE
pka_dev_init_shim: move shim->mutex initialization

### DIFF
--- a/lib/pka_dev.c
+++ b/lib/pka_dev.c
@@ -1794,6 +1794,7 @@ static int pka_dev_init_shim(pka_dev_shim_t *shim)
 
     shim->trng_enabled   = PKA_SHIM_TRNG_ENABLED;
     shim->trng_err_cycle = 0;
+    mutex_init(&shim->mutex);
 
     // Configure the TRNG
     ret = pka_dev_config_trng_drbg(&shim->resources.aic_csr,
@@ -1818,7 +1819,6 @@ static int pka_dev_init_shim(pka_dev_shim_t *shim)
         shim->trng_enabled = PKA_SHIM_TRNG_DISABLED;
     }
 
-    mutex_init(&shim->mutex);
     shim->busy_ring_num  = 0;
     shim->status         = PKA_SHIM_STATUS_INITIALIZED;
 

--- a/lib/pka_dev.h
+++ b/lib/pka_dev.h
@@ -13,6 +13,7 @@
 ///
 
 #ifdef __KERNEL__
+#include <linux/device.h>
 #include <linux/mutex.h>
 #include <linux/types.h>
 #include "pka_firmware.h"
@@ -157,6 +158,7 @@ struct pka_dev_mem_res
 /// PKA Shim structure
 struct pka_dev_shim_s
 {
+    struct device         *dev;               ///< backing struct device for devm_pka_dev_create
     struct pka_dev_mem_res mem_res;
 
     uint64_t               trng_err_cycle;    ///< TRNG error cycle
@@ -263,7 +265,8 @@ int pka_dev_unregister_ring(pka_dev_ring_t *ring);
 /// Register PKA IO block. This function initializes a shim and configures its
 /// related resources, and returns a pointer to that ring.
 pka_dev_shim_t *pka_dev_register_shim(uint32_t shim_id, uint8_t shim_fw_id,
-                                      struct pka_dev_mem_res *mem_res);
+                                      struct pka_dev_mem_res *mem_res,
+                                      struct device *dev);
 
 /// Unregister PKA IO block
 int pka_dev_unregister_shim(pka_dev_shim_t *shim);


### PR DESCRIPTION
Moved the initialization of shim->mutex before the TRNG related operations.