### PR TITLE
Fix return value check logic of pka_get_result_by_user_data

### DIFF
--- a/lib/pka.c
+++ b/lib/pka.c
@@ -1217,7 +1217,7 @@ int pka_get_result_by_user_data(pka_handle_t   handle,
     if ((void*)USER_DATA_POLLING == user_data ||
         LOCK_ACQUIRED == pka_try_acquire_lock(&gbl_info->lock.v, local_info->id, false))
     {
-        rc == pka_queue_rslt_dequeue_by_user_data(rslt_queue, &rslt_desc, results, user_data);
+        rc = pka_queue_rslt_dequeue_by_user_data(rslt_queue, &rslt_desc, results, user_data);
 
         if ( (void*)USER_DATA_POLLING != user_data )
         {


### PR DESCRIPTION
`pka_get_result_by_user_data()` retrieves the result of a completed PKA operation into `pka_results_t *results`. 

Inside `pka_get_result_by_user_data()`, `pka_queue_rslt_dequeue_by_user_data` is responsible for dequeuing a completed PKA operation result from the result queue and copying it into `pka_results_t *results`. 
However, the current implementation incorrectly handles its return value.

The return value of pka_queue_rslt_dequeue_by_user_data() reflects two conditions:
1. Whether the input queue is a valid result queue
2. Whether a result's size is available to dequeue

The first condition can be safely ignored because `pka_queue_rslt_dequeue_by_user_data()` is only ever called with a result queue.
However, the second condition is critical and must be handled correctly.

### Change
Fix the return value assignment to properly capture and check the result of pka_queue_rslt_dequeue_by_user_data().

## Before:
> `rc == pka_queue_rslt_dequeue_by_user_data(rslt_queue, &rslt_desc, results, user_data);`

## After:
> `rc = pka_queue_rslt_dequeue_by_user_data(rslt_queue, &rslt_desc, results, user_data);`

I remove a little typo (unnecessary `=`).