### PR TITLE
debian/changelog: fix stray leading lines that break dpkg-buildpackage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,3 @@
-Changes:
-
 libpka (2.0-3) UNRELEASED; urgency=low
 
     Fixed libpka fails to build on RHEL 10.2 — OpenSSL ENGINE API removed


### PR DESCRIPTION
## Summary

`debian/changelog` began with two stray lines before the first valid Debian
heading:

```
Changes:

libpka (2.0-3) UNRELEASED; urgency=low
```

Per Debian policy, the first line must be a package heading of the form
`<source> (<version>) <distribution>; urgency=<u>`. The stray `Changes:` line
and the following blank line made the file unparseable.

## The failure

`dpkg-buildpackage -b -us -uc` invokes `dpkg-parsechangelog`, which rejected the
file:

```
dpkg-parsechangelog: error: found end of file where expected first heading
```

`dpkg-buildpackage` then aborted with **rc=25**, before producing any package.

## The fix

Remove exactly the two stray leading lines (`Changes:` + blank) so the file
starts directly with `libpka (2.0-3) UNRELEASED; urgency=low`. This restores a
clean parse (rc=0). The change is limited to `debian/changelog` (2 lines
removed).

## Impact

This unblocks building the Debian/Ubuntu binary packages declared in
`debian/control`: `libpka1`, `libpka1-engine`, `libpka1-testutils`,
`libpka1-dev` (and `libpka1-doc`), and therefore all Debian-family BFB image
builds that depend on `libpka`. The RPM build path (via the `.spec` file) is
unaffected.

## Note on branch (issue vs. reality)

Issue #87 states the corruption is on the `releases` branch. In fact the
`releases` branch is already clean (it starts at `libpka (2.0-2) ...` and has no
`2.0-3` entry at all). The `Changes:` + blank corruption and the `2.0-3` entry
actually live on **`master`**, so this PR targets `master`. Issue #87 has been
updated to reflect this.

## Optional follow-up

The `2.0-3` entry is still missing its `--` maintainer/date trailer, which
`dpkg-parsechangelog` reports as a warning (not an error). It was intentionally
left out of this PR to avoid fabricating authorship — a maintainer with commit
history for the `2.0-3` work should add a proper trailer, e.g.:

```
 -- Maintainer Name <maintainer@nvidia.com>  <RFC 2822 date>
```

Fixes #87