### PR TITLE
Fix Debian changelog.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,39 +1,17 @@
-Changes:
-
 libpka (2.0-3) UNRELEASED; urgency=low
 
-    Fixed libpka fails to build on RHEL 10.2 — OpenSSL ENGINE API removed
-    
-    - Refactor parameter construction in p_bluefield.c to use OSSL_PARAM_construct_BN for better clarity and consistency. Remove unnecessary .INTERMEDIATE directive from Makefile.am.
+  * Fix build on RHEL 10.2 after OpenSSL ENGINE API removal (RM #5076015).
+  * Add OpenSSL backend auto-selection in configure.ac:
+    - build legacy ENGINE module when ENGINE API is available
+    - build OpenSSL Provider module when ENGINE API is unavailable
+      but Provider API exists (RHEL 10+)
+  * Add provider module in engine/p_bluefield.c (X25519/X448, RSA, EC/ECDSA).
+  * Update engine/Makefile.am to build libbfengine or libbfprovider.
+  * Update libpka.spec for SLES %{_docdir} and RHEL 10+ provider packaging.
+  * Fix doc build cleanup in doc/Makefile.am (.INTERMEDIATE html directory).
+  * Fix SLES 15/16 build: %{_pkgdocdir} undefined on SLES (RM #5077628).
 
-    - add OpenSSL backend auto-selection in `configure.ac`:
-      - build legacy ENGINE module when ENGINE API is available
-      - build OpenSSL Provider module when ENGINE API is unavailable but Provider API exists (RHEL 10+)
-    - add provider module implementation in `engine/p_bluefield.c` with:
-      - X25519/X448 keymgmt + keyexch
-      - RSA keymgmt + asym cipher
-      - EC keymgmt + ECDSA signature dispatch
-    - update `engine/Makefile.am` to conditionally build either `libbfengine` or `libbfprovider`
-    - update `libpka.spec`:
-      - replace `%{_pkgdocdir}` with `%{_docdir}/%{name}` for SLES compatibility
-      - package provider module on RHEL 10+ (`%{_libdir}/ossl-modules/libbfprovider.so`)
-      - keep engine packaging path for older RHEL
-      - make engine symlink creation conditional on `libbfengine.so` presence
-    - fix doc build cleanup by removing `.INTERMEDIATE: html` in `doc/Makefile.am` to avoid `unlink: html: Is a directory`
-    
-      RHEL 10.2 ships OpenSSL 3.x with legacy ENGINE APIs removed, causing libpka ENGINE build failures.
-      SLES builds also fail due to `%{_pkgdocdir}` usage in the spec.
-    
-    - `autoreconf -ifv`
-    - `./configure`
-    - `make`
-    - provider module `libbfprovider.so` builds successfully
-    
-    RM #5076015
-
-    Fix fix SLES 15/16 build — %{_pkgdocdir} macro undefined on SLES (arm64)
-    
-    RM #5077628
+ -- Shih-Yi Chen <shihyic@nvidia.com>  Thu, 11 Jun 2026 12:31:08 -0400
 
 libpka (2.0-2) UNRELEASED; urgency=low
 


### PR DESCRIPTION
The lastest debian/changelog has wrong format, so that ezchip cannot parse the correct libpka version for the deb package building.