### PR TITLE
Fix RPM packaging on RHEL 10 DPU when OpenSSL ENGINE API is absent.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,11 +107,13 @@ AS_IF([test x"$enable_engine" != x"no"],
         [ENABLED_SUBDIRS="$ENABLED_SUBDIRS engine"
         build_crypto_backend=engine
         cryptoenginesdir=$($PKG_CONFIG --variable=enginesdir --silence-errors $with_libcrypto)
+        AS_IF([test -z "$cryptoenginesdir"], [cryptoenginesdir='${libdir}/engines'])
         AC_SUBST([cryptoenginesdir])],
         [AS_IF([test x"$have_openssl_provider_api" = x"yes"],
             [ENABLED_SUBDIRS="$ENABLED_SUBDIRS engine"
             build_crypto_backend=provider
             cryptomodulesdir=$($PKG_CONFIG --variable=modulesdir --silence-errors $with_libcrypto)
+            AS_IF([test -z "$cryptomodulesdir"], [cryptomodulesdir='${libdir}/ossl-modules'])
             AC_SUBST([cryptomodulesdir])
             AC_MSG_NOTICE([OpenSSL ENGINE API unavailable; building OpenSSL Provider module instead])],
             [AC_MSG_WARN([OpenSSL ENGINE API unavailable; disabling engine/provider build])])])

--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,8 @@ libpka (2.0-3) UNRELEASED; urgency=low
   * Update libpka.spec for SLES %{_docdir} and RHEL 10+ provider packaging.
   * Fix doc build cleanup in doc/Makefile.am (.INTERMEDIATE html directory).
   * Fix SLES 15/16 build: %{_pkgdocdir} undefined on SLES (RM #5077628).
+  * Package OpenSSL engine/provider files from the configure result instead
+    of claiming engine*/*.so unconditionally (RHEL 10 DPU / OpenSSL 3.2).
 
  -- Shih-Yi Chen <shihyic@nvidia.com>  Thu, 11 Jun 2026 12:31:08 -0400
 

--- a/debian/libpka1-engine.install
+++ b/debian/libpka1-engine.install
@@ -1,1 +1,2 @@
-usr/lib/*/engines*/*.so
+# Regenerated at build time by debian/rules with whichever OpenSSL
+# module configure actually produced (libbfengine.so or libbfprovider.so).

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,15 @@ export LDFLAGS=-Wl,-Bsymbolic-functions
 %:
 	dh $@
 
-#Create engine symlink because strongswan openssl.cnf tries to load library in different places depending on distro
+# Create engine symlink because strongswan openssl.cnf tries to load the
+# library from different paths depending on distro. OpenSSL 3.2+ builds the
+# provider module instead, so only create the link when the engine exists.
+# dh_install errors on unmatched globs, so list only modules that were built.
 execute_after_dh_auto_install:
-	find $(CURDIR)/debian/ -name "*.la" -delete
-	ln -s "libbfengine.so" `find $(CURDIR)/debian/ -iname 'libbfengine.so' -printf '%h/pka.so'`
+	find $(CURDIR)/debian/tmp -name "*.la" -delete 2>/dev/null || true
+	engine_so_path=`find $(CURDIR)/debian/tmp -iname 'libbfengine.so' -print -quit 2>/dev/null || true`; \
+	if [ -n "$$engine_so_path" ]; then \
+		ln -s "libbfengine.so" "`dirname "$$engine_so_path"`/pka.so"; \
+	fi
+	{ find debian/tmp \( -name 'libbfengine.so' -o -name 'pka.so' -o -name 'libbfprovider.so' \) \
+		2>/dev/null | sed 's|^debian/tmp/||' || true; } > debian/libpka1-engine.install

--- a/libpka.spec
+++ b/libpka.spec
@@ -75,21 +75,21 @@ if [ -n "$engine_so_path" ]; then
     %{__ln_s} libbfengine.so "$engine_link_target"
 fi
 
+# Package the OpenSSL module configure actually installed (engine and/or
+# provider). %{rhel} is not reliable on DPU builders (defaults to 8 here).
+find %{buildroot} \( -name 'libbfengine.so' -o -name 'pka.so' -o -name 'libbfprovider.so' \) \
+    | sed "s|^%{buildroot}||" | sort -u > openssl-crypto-module.files
+
 %files
 %defattr(-, root, root)
 %license %{_docdir}/%{name}/COPYING
 %doc %{_docdir}/%{name}/README
 %{_libdir}/*.so*
 
-%files engine
+%files engine -f openssl-crypto-module.files
 %defattr(-, root, root)
 %license %{_docdir}/%{name}/COPYING
 %doc %{_docdir}/%{name}/README.engine
-%if 0%{?rhel} >= 10
-%{_libdir}/ossl-modules/libbfprovider.so
-%else
-%{_libdir}/engine*/*.so
-%endif
 
 %files testutils
 %defattr(-, root, root)


### PR DESCRIPTION
Package the engine/provider .so from the configure install result instead of claiming engine*/*.so from %{rhel}, which DPU builders leave unset.

RM #5227107